### PR TITLE
Handle JS errors when streaming video

### DIFF
--- a/ts/lib.ts
+++ b/ts/lib.ts
@@ -217,7 +217,11 @@ class PointerHandler {
 }
 
 function frame_timer(webSocket: WebSocket) {
-    webSocket.send('"TryGetFrame"');
+    if (webSocket.readyState > webSocket.OPEN)  // Closing or closed, so no more frames
+        return;
+
+    if (webSocket.readyState === webSocket.OPEN)
+        webSocket.send('"TryGetFrame"');
     let upd_limit = settings.frame_update_limit();
     if (upd_limit > 0)
         setTimeout(() => frame_timer(webSocket), upd_limit);

--- a/ts/lib.ts
+++ b/ts/lib.ts
@@ -243,7 +243,15 @@ function handle_messages(
         if (sourceBuffer == null)
             return;
         if (!sourceBuffer.updating && queue.length > 0 && mediaSource.readyState == "open") {
-            sourceBuffer.appendBuffer(queue.shift());
+            try {
+                sourceBuffer.appendBuffer(queue.shift());
+            } catch (err) {
+                console.log("Error appending to sourceBuffer:", err);
+                // Drop everything, and try to pick up the stream again
+                if (sourceBuffer.updating)
+                    sourceBuffer.abort();
+                sourceBuffer.remove(0, Infinity);
+            }
         }
     }
     webSocket.onmessage = (event: MessageEvent) => {


### PR DESCRIPTION
This handles two JS errors I've encountered in the video streaming system.

The first is that the state of the websocket was not checked before requesting another frame.  This lead to a large number of harmless errors when the websocket was closed.  This fix stops requesting frames when the websocket is no longer open, and only requests a frame when it is open.

The more important error was a QuotaExceededError when the sourceBuffer got too large.  (See [here](https://developers.google.com/web/updates/2017/10/quotaexceedederror) and [here](https://stackoverflow.com/questions/53309874/sourcebuffer-removestart-end-removes-whole-buffered-timerange-how-to-handle) for some discussion.)  It appears that browsers allot a certain amount of memory for these buffers, and they try to discard data when they're getting close to this limit.  Firefox, at least, does this imperfectly, resulting in these errors if it wasn't able to clear data quickly enough to make room for the new data coming in.  This solution goes for the nuclear option: If you can't append data to the buffer, remove everything and let it recover with the next frame (or more likely, keyframe) to come in.