### PR TITLE
Limit the length of the sourceBuffer

### DIFF
--- a/ts/lib.ts
+++ b/ts/lib.ts
@@ -217,7 +217,11 @@ class PointerHandler {
 }
 
 function frame_timer(webSocket: WebSocket) {
-    webSocket.send('"TryGetFrame"');
+    if (webSocket.readyState > webSocket.OPEN)  // Closing or closed, so no more frames
+        return;
+
+    if (webSocket.readyState === webSocket.OPEN)
+        webSocket.send('"TryGetFrame"');
     let upd_limit = settings.frame_update_limit();
     if (upd_limit > 0)
         setTimeout(() => frame_timer(webSocket), upd_limit);

--- a/ts/lib.ts
+++ b/ts/lib.ts
@@ -239,7 +239,7 @@ function handle_messages(
     let mediaSource: MediaSource = null;
     let sourceBuffer: SourceBuffer = null;
     let queue = [];
-    const BUFFER_LENGTH = 10;  // In seconds
+    const MAX_BUFFER_LENGTH = 20;  // In seconds
     function upd_buf() {
         if (sourceBuffer == null)
             return;
@@ -249,8 +249,8 @@ function handle_messages(
                 // Assume only one time range...
                 buffer_length = sourceBuffer.buffered.end(0) - sourceBuffer.buffered.start(0);
             }
-            if (buffer_length > 2 * BUFFER_LENGTH) {
-                sourceBuffer.remove(0, sourceBuffer.buffered.end(0) - BUFFER_LENGTH);
+            if (buffer_length > MAX_BUFFER_LENGTH) {
+                sourceBuffer.remove(0, sourceBuffer.buffered.end(0) - MAX_BUFFER_LENGTH / 2);
                 // This will trigger updateend when finished
             } else {
                 try {

--- a/ts/lib.ts
+++ b/ts/lib.ts
@@ -243,7 +243,15 @@ function handle_messages(
         if (sourceBuffer == null)
             return;
         if (!sourceBuffer.updating && queue.length > 0 && mediaSource.readyState == "open") {
-            sourceBuffer.appendBuffer(queue.shift());
+            try {
+                sourceBuffer.appendBuffer(queue.shift());
+            } catch (err) {
+                console.log("Error appending to sourceBuffer:", err);
+                // Drop everything, and try to pick up the stream again
+                if (sourceBuffer.updating)
+                    sourceBuffer.abort();
+                sourceBuffer.remove(0, Infinity);
+            }
         }
     }
     webSocket.onmessage = (event: MessageEvent) => {


### PR DESCRIPTION
This PR builds on the changes of #28, but it's different enough that I thought it should live in it's own PR.

By default, the sourceBuffer can grow to several hundred MB, depending
on browser settings.  This can decrease performance and (apparently)
occasionally crash browser tabs.  However, we only care about the end
of the buffer, so most of this use is completely wasted on us.  Ideally,
there would be a setting that said, don't keep frames after they've
been displayed, but if there is, I haven't found it.

This solution sets a target buffer length, 10s as a more-or-less
random value.  (Browsers often got 100s of buffer, so this is 1/10 of
that.  Realistically, anything over a second is probably useless from
a UX experience, so 10s sits in the middle.  We also need to make sure
this is longer than the time between keyframes.)  When the buffer
length exceeds twice the target length, it is trimmed to the target
length.  In limited testing, this seems to improve memory performance,
and I have not seen a crashed tab.