### PR TITLE
Better USB (adb) integration [Do not merge]

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -7,6 +7,7 @@ List of Contributors:
 **************************
 Robert Schroll
 Daniel Rutz
+Philipp Urlbauer
 **************************
 
 3-Clause BSD License

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,6 +170,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
+name = "captrs"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dad312f1be0ea3cce9ad0cdbace33350ea0781f138d7b49bfe191df0aa83db1b"
+dependencies = [
+ "dxgcap",
+ "x11cap",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -426,6 +436,16 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "dxgcap"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18a3f3df51c509e7c8d2807c63abfecdea1a83def81baec83d68c6f5bb8ac654"
+dependencies = [
+ "winapi 0.3.9",
+ "wio",
 ]
 
 [[package]]
@@ -2510,6 +2530,7 @@ version = "0.11.4"
 dependencies = [
  "autopilot",
  "bitflags 1.3.2",
+ "captrs",
  "cc",
  "core-foundation 0.9.1",
  "core-graphics 0.22.2",
@@ -2536,6 +2557,8 @@ dependencies = [
  "tracing-subscriber",
  "url 2.2.2",
  "websocket",
+ "winapi 0.3.9",
+ "wio",
 ]
 
 [[package]]
@@ -2573,6 +2596,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "wio"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d129932f4644ac2396cb456385cbf9e63b5b30c6e8dc4820bdca4eb082037a5"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "ws2_32-sys"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2590,4 +2622,14 @@ checksum = "77ecd092546cb16f25783a5451538e73afc8d32e242648d54f4ae5459ba1e773"
 dependencies = [
  "libc",
  "pkg-config",
+]
+
+[[package]]
+name = "x11cap"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16ccedf556cb1f784d462dd8f24a7804f766d57c0051439d3e4052465263c399"
+dependencies = [
+ "libc",
+ "x11",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ toml = "^0.5"
 structopt = { version = "^0.3", features = ["color", "suggestions"], default-features = false }
 dirs = "^3.0"
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3.8", features = ["d3d11", "d3dcommon", "dxgi", "dxgi1_2", "dxgitype", "ntdef", "unknwnbase", "windef", "winerror", "winuser"] }
+winapi = { version = "0.3.8", features = ["d3d11", "d3dcommon", "dxgi", "dxgi1_2", "dxgitype"] }
 wio = "0.2.2"
 captrs = "^0.3.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,8 @@ percent-encoding = "2.1.0"
 toml = "^0.5"
 structopt = { version = "^0.3", features = ["color", "suggestions"], default-features = false }
 dirs = "^3.0"
+[target.'cfg(windows)'.dependencies]
+winapi = { version = "0.3", features = ["winuser"] }
 
 [build-dependencies]
 cc = "^1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,9 @@ toml = "^0.5"
 structopt = { version = "^0.3", features = ["color", "suggestions"], default-features = false }
 dirs = "^3.0"
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["winuser"] }
+winapi = { version = "0.3.8", features = ["d3d11", "d3dcommon", "dxgi", "dxgi1_2", "dxgitype", "ntdef", "unknwnbase", "windef", "winerror", "winuser"] }
+wio = "0.2.2"
+captrs = "^0.3.1"
 
 [build-dependencies]
 cc = "^1.0"

--- a/build.rs
+++ b/build.rs
@@ -32,32 +32,6 @@ fn main() {
         build_ffmpeg();
     }
 
-    println!("cargo:rerun-if-changed=ts/lib.ts");
-
-    #[cfg(not(target_os = "windows"))]
-    let mut tsc_command = Command::new("tsc");
-
-    #[cfg(target_os = "windows")]
-    let mut tsc_command = Command::new("bash");
-    #[cfg(target_os = "windows")]
-    tsc_command.arg("tsc");
-
-    match tsc_command.status() {
-        Err(err) => {
-            println!("cargo:warning=Failed to call tsc: {}", err);
-            std::process::exit(1);
-        }
-        Ok(status) => {
-            if !status.success() {
-                match status.code() {
-                    Some(code) => println!("cargo:warning=tsc failed with exitcode: {}", code),
-                    None => println!("cargo:warning=tsc terminated by signal."),
-                };
-                std::process::exit(2);
-            }
-        }
-    }
-
     println!("cargo:rerun-if-changed=lib/error.h");
     println!("cargo:rerun-if-changed=lib/error.c");
     println!("cargo:rerun-if-changed=lib/log.h");
@@ -136,6 +110,7 @@ fn linux() {
         .file("lib/linux/xhelper.c")
         .compile("linux");
 
+    println!("cargo:rustc-link-lib=pango-1.0");
     println!("cargo:rustc-link-lib=X11");
     println!("cargo:rustc-link-lib=Xext");
     println!("cargo:rustc-link-lib=Xrandr");

--- a/src/capturable/autopilot.rs
+++ b/src/capturable/autopilot.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 
 use image_autopilot::GenericImageView;
 
-use crate::capturable::{Capturable, Recorder};
+use crate::capturable::{Capturable, Geometry, Recorder};
 
 #[derive(Clone)]
 pub struct AutoPilotCapturable {}
@@ -18,20 +18,14 @@ impl Capturable for AutoPilotCapturable {
     fn name(&self) -> String {
         "Desktop (autopilot)".into()
     }
-    fn geometry_relative(&self) -> Result<(f64, f64, f64, f64), Box<dyn Error>> {
-        Ok((0.0, 0.0, 1.0, 1.0))
+    fn geometry(&self) -> Result<Geometry, Box<dyn Error>> {
+        Ok(Geometry::Relative(0.0, 0.0, 1.0, 1.0))
     }
     fn before_input(&mut self) -> Result<(), Box<dyn Error>> {
         Ok(())
     }
     fn recorder(&self, _capture_cursor: bool) -> Result<Box<dyn Recorder>, Box<dyn Error>> {
         Ok(Box::new(RecorderAutoPilot::new()))
-    }
-    fn geometry(&self) -> Result<(u32, u32), Box<dyn Error>> {
-        Ok((0, 0))
-    }
-    fn geometry_offset(&self) -> Result<(i32, i32), Box<dyn Error>> {
-        Ok((0, 0))
     }
 }
 

--- a/src/capturable/autopilot.rs
+++ b/src/capturable/autopilot.rs
@@ -27,6 +27,12 @@ impl Capturable for AutoPilotCapturable {
     fn recorder(&self, _capture_cursor: bool) -> Result<Box<dyn Recorder>, Box<dyn Error>> {
         Ok(Box::new(RecorderAutoPilot::new()))
     }
+    fn geometry(&self) -> Result<(u32, u32), Box<dyn Error>> {
+        Ok((0, 0))
+    }
+    fn geometry_offset(&self) -> Result<(i32, i32), Box<dyn Error>> {
+        Ok((0, 0))
+    }
 }
 
 pub struct RecorderAutoPilot {

--- a/src/capturable/captrs_capture.rs
+++ b/src/capturable/captrs_capture.rs
@@ -2,6 +2,7 @@ use crate::capturable::{Capturable, Recorder};
 use captrs::Capturer;
 use std::boxed::Box;
 use std::error::Error;
+use winapi::shared::windef::RECT;
 
 use super::Geometry;
 
@@ -9,28 +10,17 @@ use super::Geometry;
 pub struct CaptrsCapturable {
     id: u8,
     name: String,
-    width: u32,
-    height: u32,
-    offset_x: i32,
-    offset_y: i32,
+    screen: RECT,
+    virtual_screen: RECT,
 }
 
 impl CaptrsCapturable {
-    pub fn new(
-        id: u8,
-        name: String,
-        width: u32,
-        height: u32,
-        offset_x: i32,
-        offset_y: i32,
-    ) -> CaptrsCapturable {
+    pub fn new(id: u8, name: String, screen: RECT, virtual_screen: RECT) -> CaptrsCapturable {
         CaptrsCapturable {
             id,
             name,
-            width,
-            height,
-            offset_x,
-            offset_y,
+            screen,
+            virtual_screen,
         }
     }
 }
@@ -47,10 +37,12 @@ impl Capturable for CaptrsCapturable {
     }
     fn geometry(&self) -> Result<Geometry, Box<dyn Error>> {
         Ok(Geometry::VirtualScreen(
-            self.offset_x,
-            self.offset_y,
-            self.width,
-            self.height,
+            self.screen.left - self.virtual_screen.left,
+            self.screen.top - self.virtual_screen.top,
+            (self.screen.right - self.screen.left) as u32,
+            (self.screen.bottom - self.screen.top) as u32,
+            self.screen.left,
+            self.screen.top,
         ))
     }
 }

--- a/src/capturable/captrs_capture.rs
+++ b/src/capturable/captrs_capture.rs
@@ -81,7 +81,7 @@ impl Recorder for CaptrsRecorder {
     fn capture(&mut self) -> Result<crate::video::PixelProvider, Box<dyn Error>> {
         self.capturer
             .capture_store_frame()
-            .map_err(|e| CaptrsError("Captrs failed to capture frame".into()))?;
+            .map_err(|_e| CaptrsError("Captrs failed to capture frame".into()))?;
         let (w, h) = self.capturer.geometry();
         Ok(crate::video::PixelProvider::BGR0(
             w as usize,

--- a/src/capturable/captrs_capture.rs
+++ b/src/capturable/captrs_capture.rs
@@ -43,7 +43,7 @@ impl Capturable for CaptrsCapturable {
         Ok(())
     }
     fn recorder(&self, _capture_cursor: bool) -> Result<Box<dyn Recorder>, Box<dyn Error>> {
-        Ok(Box::new(CaptrsRecorder::new(self.id)))
+        Ok(Box::new(CaptrsRecorder::new(self.id)?))
     }
     fn geometry(&self) -> Result<Geometry, Box<dyn Error>> {
         Ok(Geometry::VirtualScreen(
@@ -70,10 +70,10 @@ pub struct CaptrsRecorder {
 }
 
 impl CaptrsRecorder {
-    pub fn new(id: u8) -> CaptrsRecorder {
-        CaptrsRecorder {
+    pub fn new(id: u8) -> Result<CaptrsRecorder, Box<dyn Error>> {
+        Ok(CaptrsRecorder {
             capturer: Capturer::new(id.into()).unwrap(),
-        }
+        })
     }
 }
 

--- a/src/capturable/captrs_capture.rs
+++ b/src/capturable/captrs_capture.rs
@@ -3,6 +3,8 @@ use captrs::Capturer;
 use std::boxed::Box;
 use std::error::Error;
 
+use super::Geometry;
+
 #[derive(Clone)]
 pub struct CaptrsCapturable {
     id: u8,
@@ -28,20 +30,19 @@ impl Capturable for CaptrsCapturable {
     fn name(&self) -> String {
         format!("Desktop {} (captrs)", self.id).into()
     }
-    fn geometry_relative(&self) -> Result<(f64, f64, f64, f64), Box<dyn Error>> {
-        Ok((0.0, 0.0, 1.0, 1.0))
-    }
     fn before_input(&mut self) -> Result<(), Box<dyn Error>> {
         Ok(())
     }
     fn recorder(&self, _capture_cursor: bool) -> Result<Box<dyn Recorder>, Box<dyn Error>> {
         Ok(Box::new(CaptrsRecorder::new(self.id)))
     }
-    fn geometry(&self) -> Result<(u32, u32), Box<dyn Error>> {
-        Ok((self.width, self.height))
-    }
-    fn geometry_offset(&self) -> Result<(i32, i32), Box<dyn Error>> {
-        Ok((self.offset_x, self.offset_y))
+    fn geometry(&self) -> Result<Geometry, Box<dyn Error>> {
+        Ok(Geometry::VirtualScreen(
+            self.offset_x,
+            self.offset_y,
+            self.width,
+            self.height,
+        ))
     }
 }
 

--- a/src/capturable/captrs_capture.rs
+++ b/src/capturable/captrs_capture.rs
@@ -1,0 +1,70 @@
+use crate::capturable::{Capturable, Recorder};
+use captrs::Capturer;
+use std::boxed::Box;
+use std::error::Error;
+
+#[derive(Clone)]
+pub struct CaptrsCapturable {
+    id: u8,
+    width: u32,
+    height: u32,
+    offset_x: i32,
+    offset_y: i32,
+}
+
+impl CaptrsCapturable {
+    pub fn new(id: u8, width: u32, height: u32, offset_x: i32, offset_y: i32) -> CaptrsCapturable {
+        CaptrsCapturable {
+            id,
+            width,
+            height,
+            offset_x,
+            offset_y,
+        }
+    }
+}
+
+impl Capturable for CaptrsCapturable {
+    fn name(&self) -> String {
+        format!("Desktop {} (captrs)", self.id).into()
+    }
+    fn geometry_relative(&self) -> Result<(f64, f64, f64, f64), Box<dyn Error>> {
+        Ok((0.0, 0.0, 1.0, 1.0))
+    }
+    fn before_input(&mut self) -> Result<(), Box<dyn Error>> {
+        Ok(())
+    }
+    fn recorder(&self, _capture_cursor: bool) -> Result<Box<dyn Recorder>, Box<dyn Error>> {
+        Ok(Box::new(CaptrsRecorder::new(self.id)))
+    }
+    fn geometry(&self) -> Result<(u32, u32), Box<dyn Error>> {
+        Ok((self.width, self.height))
+    }
+    fn geometry_offset(&self) -> Result<(i32, i32), Box<dyn Error>> {
+        Ok((self.offset_x, self.offset_y))
+    }
+}
+
+pub struct CaptrsRecorder {
+    capturer: Capturer,
+}
+
+impl CaptrsRecorder {
+    pub fn new(id: u8) -> CaptrsRecorder {
+        CaptrsRecorder {
+            capturer: Capturer::new(id.into()).unwrap(),
+        }
+    }
+}
+
+impl Recorder for CaptrsRecorder {
+    fn capture(&mut self) -> Result<crate::video::PixelProvider, Box<dyn Error>> {
+        let _ = self.capturer.capture_store_frame();
+        let (w, h) = self.capturer.geometry();
+        Ok(crate::video::PixelProvider::BGR0(
+            w as usize,
+            h as usize,
+            unsafe { std::mem::transmute(self.capturer.get_stored_frame().unwrap()) },
+        ))
+    }
+}

--- a/src/capturable/captrs_capture.rs
+++ b/src/capturable/captrs_capture.rs
@@ -8,6 +8,7 @@ use super::Geometry;
 #[derive(Clone)]
 pub struct CaptrsCapturable {
     id: u8,
+    name: String,
     width: u32,
     height: u32,
     offset_x: i32,
@@ -15,9 +16,17 @@ pub struct CaptrsCapturable {
 }
 
 impl CaptrsCapturable {
-    pub fn new(id: u8, width: u32, height: u32, offset_x: i32, offset_y: i32) -> CaptrsCapturable {
+    pub fn new(
+        id: u8,
+        name: String,
+        width: u32,
+        height: u32,
+        offset_x: i32,
+        offset_y: i32,
+    ) -> CaptrsCapturable {
         CaptrsCapturable {
             id,
+            name,
             width,
             height,
             offset_x,
@@ -28,7 +37,7 @@ impl CaptrsCapturable {
 
 impl Capturable for CaptrsCapturable {
     fn name(&self) -> String {
-        format!("Desktop {} (captrs)", self.id).into()
+        format!("Desktop {} (captrs)", self.name).into()
     }
     fn before_input(&mut self) -> Result<(), Box<dyn Error>> {
         Ok(())

--- a/src/capturable/captrs_capture.rs
+++ b/src/capturable/captrs_capture.rs
@@ -54,7 +54,17 @@ impl Capturable for CaptrsCapturable {
         ))
     }
 }
+#[derive(Debug)]
+pub struct CaptrsError(String);
 
+impl std::fmt::Display for CaptrsError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self(s) = self;
+        write!(f, "{}", s)
+    }
+}
+
+impl Error for CaptrsError {}
 pub struct CaptrsRecorder {
     capturer: Capturer,
 }
@@ -69,7 +79,9 @@ impl CaptrsRecorder {
 
 impl Recorder for CaptrsRecorder {
     fn capture(&mut self) -> Result<crate::video::PixelProvider, Box<dyn Error>> {
-        let _ = self.capturer.capture_store_frame();
+        self.capturer
+            .capture_store_frame()
+            .map_err(|e| CaptrsError("Captrs failed to capture frame".into()))?;
         let (w, h) = self.capturer.geometry();
         Ok(crate::video::PixelProvider::BGR0(
             w as usize,

--- a/src/capturable/captrs_capture.rs
+++ b/src/capturable/captrs_capture.rs
@@ -72,7 +72,7 @@ pub struct CaptrsRecorder {
 impl CaptrsRecorder {
     pub fn new(id: u8) -> Result<CaptrsRecorder, Box<dyn Error>> {
         Ok(CaptrsRecorder {
-            capturer: Capturer::new(id.into()).unwrap(),
+            capturer: Capturer::new(id.into())?,
         })
     }
 }

--- a/src/capturable/core_graphics.rs
+++ b/src/capturable/core_graphics.rs
@@ -71,6 +71,14 @@ impl Capturable for CGDisplayCapturable {
             capture_cursor,
         )))
     }
+
+    fn geometry(&self) -> Result<(u32, u32), Box<dyn Error>> {
+        Ok((0, 0))
+    }
+
+    fn geometry_offset(&self) -> Result<(i32, i32), Box<dyn Error>> {
+        Ok((0, 0))
+    }
 }
 
 pub struct RecorderCGDisplay {

--- a/src/capturable/core_graphics.rs
+++ b/src/capturable/core_graphics.rs
@@ -176,7 +176,8 @@ impl Capturable for CGWindowCapturable {
         self.name.clone()
     }
     fn geometry(&self) -> Result<Geometry, Box<dyn Error>> {
-        Ok(Geometry::Relative(self.geometry_relative))
+        let (x, y, w, h) = self.geometry_relative;
+        Ok(Geometry::Relative(x, y, w, h))
     }
     fn before_input(&mut self) -> Result<(), Box<dyn Error>> {
         self.update_geometry()

--- a/src/capturable/core_graphics.rs
+++ b/src/capturable/core_graphics.rs
@@ -19,7 +19,7 @@ use core_graphics::{
     window::CGWindowID,
 };
 
-use crate::capturable::{Capturable, Recorder};
+use crate::capturable::{Capturable, Geometry, Recorder};
 
 #[derive(Debug)]
 pub struct CGError(String);
@@ -52,10 +52,10 @@ impl Capturable for CGDisplayCapturable {
             self.display.pixels_high()
         )
     }
-    fn geometry_relative(&self) -> Result<(f64, f64, f64, f64), Box<dyn Error>> {
+    fn geometry(&self) -> Result<Geometry, Box<dyn Error>> {
         let bounds = self.display.bounds();
         let (x0, y0, w, h) = screen_coordsys()?;
-        Ok((
+        Ok(Geometry::Relative(
             (bounds.origin.x - x0) / w,
             (bounds.origin.y - y0) / h,
             bounds.size.width / w,
@@ -70,14 +70,6 @@ impl Capturable for CGDisplayCapturable {
             self.display,
             capture_cursor,
         )))
-    }
-
-    fn geometry(&self) -> Result<(u32, u32), Box<dyn Error>> {
-        Ok((0, 0))
-    }
-
-    fn geometry_offset(&self) -> Result<(i32, i32), Box<dyn Error>> {
-        Ok((0, 0))
     }
 }
 
@@ -183,8 +175,8 @@ impl Capturable for CGWindowCapturable {
     fn name(&self) -> String {
         self.name.clone()
     }
-    fn geometry_relative(&self) -> Result<(f64, f64, f64, f64), Box<dyn Error>> {
-        Ok(self.geometry_relative)
+    fn geometry(&self) -> Result<Geometry, Box<dyn Error>> {
+        Ok(Geometry::Relative(self.geometry_relative))
     }
     fn before_input(&mut self) -> Result<(), Box<dyn Error>> {
         self.update_geometry()

--- a/src/capturable/mod.rs
+++ b/src/capturable/mod.rs
@@ -34,7 +34,9 @@ where
         Box::new(self.clone())
     }
 }
-
+/// Relative: x, y, width, height of the Capturable as floats relative to the absolute size of the
+/// screen. For example x=0.5, y=0.0, width=0.5, height=1.0 means the right half of the screen.
+/// VirtualScreen: offset_x, offset_y, width, height for a capturable using a virtual screen. (Windows)
 pub enum Geometry {
     Relative(f64, f64, f64, f64),
     VirtualScreen(i32, i32, u32, u32),
@@ -44,9 +46,7 @@ pub trait Capturable: Send + BoxCloneCapturable {
     /// Name of the Capturable, for example the window title, if it is a window.
     fn name(&self) -> String;
 
-    /// Return x, y, width, height of the Capturable as floats relative to the absolute size of the
-    /// screen. For example x=0.5, y=0.0, width=0.5, height=1.0 means the right half of the screen.
-    /// Or offset_x, offset_y, width, height for a capturable using a virtual screen. (Windows)
+    /// Return Geometry of the Capturable.
     fn geometry(&self) -> Result<Geometry, Box<dyn Error>>;
 
     /// Callback that is called right before input is simulated.
@@ -130,10 +130,11 @@ pub fn get_capturables(
         for (i, o) in winctx.get_outputs().iter().enumerate() {
             let captr = CaptrsCapturable::new(
                 i as u8,
-                (o.right - o.left) as u32,
-                (o.bottom - o.top) as u32,
-                o.left - winctx.get_union_rect().left,
-                o.top - winctx.get_union_rect().top,
+                String::from_utf16_lossy(o.DeviceName.as_ref()),
+                (o.DesktopCoordinates.right - o.DesktopCoordinates.left) as u32,
+                (o.DesktopCoordinates.bottom - o.DesktopCoordinates.top) as u32,
+                o.DesktopCoordinates.left - winctx.get_union_rect().left,
+                o.DesktopCoordinates.top - winctx.get_union_rect().top,
             );
             capturables.push(Box::new(captr));
         }

--- a/src/capturable/mod.rs
+++ b/src/capturable/mod.rs
@@ -35,13 +35,19 @@ where
     }
 }
 
+pub enum Geometry {
+    Relative(f64, f64, f64, f64),
+    VirtualScreen(i32, i32, u32, u32),
+}
+
 pub trait Capturable: Send + BoxCloneCapturable {
     /// Name of the Capturable, for example the window title, if it is a window.
     fn name(&self) -> String;
 
     /// Return x, y, width, height of the Capturable as floats relative to the absolute size of the
     /// screen. For example x=0.5, y=0.0, width=0.5, height=1.0 means the right half of the screen.
-    fn geometry_relative(&self) -> Result<(f64, f64, f64, f64), Box<dyn Error>>;
+    /// Or offset_x, offset_y, width, height for a capturable using a virtual screen. (Windows)
+    fn geometry(&self) -> Result<Geometry, Box<dyn Error>>;
 
     /// Callback that is called right before input is simulated.
     /// Useful to focus the window on input.
@@ -49,8 +55,6 @@ pub trait Capturable: Send + BoxCloneCapturable {
 
     /// Return a Recorder that can record the current capturable.
     fn recorder(&self, capture_cursor: bool) -> Result<Box<dyn Recorder>, Box<dyn Error>>;
-    fn geometry(&self) -> Result<(u32, u32), Box<dyn Error>>;
-    fn geometry_offset(&self) -> Result<(i32, i32), Box<dyn Error>>;
 }
 
 impl Clone for Box<dyn Capturable> {

--- a/src/capturable/mod.rs
+++ b/src/capturable/mod.rs
@@ -1,4 +1,5 @@
 pub mod autopilot;
+
 use std::boxed::Box;
 use std::error::Error;
 use tracing::warn;
@@ -10,9 +11,13 @@ pub mod pipewire;
 #[cfg(target_os = "linux")]
 pub mod pipewire_dbus;
 pub mod testsrc;
+
+#[cfg(target_os = "windows")]
+pub mod captrs_capture;
+#[cfg(target_os = "windows")]
+pub mod win_ctx;
 #[cfg(target_os = "linux")]
 pub mod x11;
-
 pub trait Recorder {
     fn capture(&mut self) -> Result<crate::video::PixelProvider, Box<dyn Error>>;
 }
@@ -44,6 +49,8 @@ pub trait Capturable: Send + BoxCloneCapturable {
 
     /// Return a Recorder that can record the current capturable.
     fn recorder(&self, capture_cursor: bool) -> Result<Box<dyn Recorder>, Box<dyn Error>>;
+    fn geometry(&self) -> Result<(u32, u32), Box<dyn Error>>;
+    fn geometry_offset(&self) -> Result<(i32, i32), Box<dyn Error>>;
 }
 
 impl Clone for Box<dyn Capturable> {
@@ -111,8 +118,22 @@ pub fn get_capturables(
         }
     }
 
-    use crate::capturable::autopilot::AutoPilotCapturable;
-    capturables.push(Box::new(AutoPilotCapturable::new()));
+    #[cfg(target_os = "windows")]
+    {
+        use crate::capturable::captrs_capture::CaptrsCapturable;
+        use crate::capturable::win_ctx::WinCtx;
+        let winctx = WinCtx::new();
+        for (i, o) in winctx.get_outputs().iter().enumerate() {
+            let captr = CaptrsCapturable::new(
+                i as u8,
+                (o.right - o.left) as u32,
+                (o.bottom - o.top) as u32,
+                o.left - winctx.get_union_rect().left,
+                o.top - winctx.get_union_rect().top,
+            );
+            capturables.push(Box::new(captr));
+        }
+    }
 
     if crate::log::get_log_level() >= tracing::Level::DEBUG {
         for (width, height) in [

--- a/src/capturable/mod.rs
+++ b/src/capturable/mod.rs
@@ -39,7 +39,7 @@ where
 /// VirtualScreen: offset_x, offset_y, width, height for a capturable using a virtual screen. (Windows)
 pub enum Geometry {
     Relative(f64, f64, f64, f64),
-    VirtualScreen(i32, i32, u32, u32),
+    VirtualScreen(i32, i32, u32, u32, i32, i32),
 }
 
 pub trait Capturable: Send + BoxCloneCapturable {
@@ -131,10 +131,8 @@ pub fn get_capturables(
             let captr = CaptrsCapturable::new(
                 i as u8,
                 String::from_utf16_lossy(o.DeviceName.as_ref()),
-                (o.DesktopCoordinates.right - o.DesktopCoordinates.left) as u32,
-                (o.DesktopCoordinates.bottom - o.DesktopCoordinates.top) as u32,
-                o.DesktopCoordinates.left - winctx.get_union_rect().left,
-                o.DesktopCoordinates.top - winctx.get_union_rect().top,
+                o.DesktopCoordinates,
+                winctx.get_union_rect().clone(),
             );
             capturables.push(Box::new(captr));
         }

--- a/src/capturable/pipewire.rs
+++ b/src/capturable/pipewire.rs
@@ -107,6 +107,14 @@ impl Capturable for PipeWireCapturable {
     fn recorder(&self, capture_cursor: bool) -> Result<Box<dyn Recorder>, Box<dyn Error>> {
         Ok(Box::new(PipeWireRecorder::new(self.clone())?))
     }
+
+    fn geometry(&self) -> Result<(u32, u32), Box<dyn Error>> {
+        Ok((0, 0))
+    }
+
+    fn geometry_offset(&self) -> Result<(i32, i32), Box<dyn Error>> {
+        Ok((0, 0))
+    }
 }
 
 pub struct PipeWireRecorder {
@@ -327,7 +335,9 @@ fn streams_from_response(response: OrgFreedesktopPortalRequestResponse) -> Vec<P
                         .collect::<HashMap<String, &dyn RefArg>>();
                     Some(PwStreamInfo {
                         path,
-                        source_type: attributes.get("source_type").map_or(Some(0), |v| v.as_u64())?,
+                        source_type: attributes
+                            .get("source_type")
+                            .map_or(Some(0), |v| v.as_u64())?,
                     })
                 })
                 .collect::<Vec<PwStreamInfo>>(),

--- a/src/capturable/pipewire.rs
+++ b/src/capturable/pipewire.rs
@@ -16,7 +16,7 @@ use gstreamer as gst;
 use gstreamer::prelude::*;
 use gstreamer_app::AppSink;
 
-use crate::capturable::{Capturable, Recorder};
+use crate::capturable::{Capturable, Geometry, Recorder};
 use crate::video::PixelProvider;
 
 use crate::capturable::pipewire_dbus::{

--- a/src/capturable/pipewire.rs
+++ b/src/capturable/pipewire.rs
@@ -96,8 +96,8 @@ impl Capturable for PipeWireCapturable {
         format!("Pipewire {}, path: {}", type_str, self.path)
     }
 
-    fn geometry_relative(&self) -> Result<(f64, f64, f64, f64), Box<dyn Error>> {
-        Ok((0.0, 0.0, 1.0, 1.0))
+    fn geometry(&self) -> Result<Geometry, Box<dyn Error>> {
+        Ok(Geometry::Relative(0.0, 0.0, 1.0, 1.0))
     }
 
     fn before_input(&mut self) -> Result<(), Box<dyn Error>> {
@@ -106,14 +106,6 @@ impl Capturable for PipeWireCapturable {
 
     fn recorder(&self, capture_cursor: bool) -> Result<Box<dyn Recorder>, Box<dyn Error>> {
         Ok(Box::new(PipeWireRecorder::new(self.clone())?))
-    }
-
-    fn geometry(&self) -> Result<(u32, u32), Box<dyn Error>> {
-        Ok((0, 0))
-    }
-
-    fn geometry_offset(&self) -> Result<(i32, i32), Box<dyn Error>> {
-        Ok((0, 0))
     }
 }
 

--- a/src/capturable/testsrc.rs
+++ b/src/capturable/testsrc.rs
@@ -52,6 +52,12 @@ impl Capturable for TestCapturable {
     fn recorder(&self, _: bool) -> Result<Box<dyn Recorder>, Box<dyn Error>> {
         Ok(Box::new(TestRecorder::new(*self)))
     }
+    fn geometry(&self) -> Result<(u32, u32), Box<dyn Error>> {
+        Ok((0, 0))
+    }
+    fn geometry_offset(&self) -> Result<(i32, i32), Box<dyn Error>> {
+        Ok((0, 0))
+    }
 }
 
 impl Recorder for TestRecorder {

--- a/src/capturable/testsrc.rs
+++ b/src/capturable/testsrc.rs
@@ -1,4 +1,4 @@
-use crate::capturable::{Capturable, Recorder};
+use crate::capturable::{Capturable, Geometry, Recorder};
 use crate::video::PixelProvider;
 use std::error::Error;
 
@@ -43,20 +43,14 @@ impl Capturable for TestCapturable {
     fn name(&self) -> String {
         format!("Test Source {}x{}", self.width, self.height)
     }
-    fn geometry_relative(&self) -> Result<(f64, f64, f64, f64), Box<dyn Error>> {
-        Ok((1.0, 1.0, 1.0, 1.0))
+    fn geometry(&self) -> Result<Geometry, Box<dyn Error>> {
+        Ok(Geometry::Relative(0.0, 0.0, 1.0, 1.0))
     }
     fn before_input(&mut self) -> Result<(), Box<dyn Error>> {
         Ok(())
     }
     fn recorder(&self, _: bool) -> Result<Box<dyn Recorder>, Box<dyn Error>> {
         Ok(Box::new(TestRecorder::new(*self)))
-    }
-    fn geometry(&self) -> Result<(u32, u32), Box<dyn Error>> {
-        Ok((0, 0))
-    }
-    fn geometry_offset(&self) -> Result<(i32, i32), Box<dyn Error>> {
-        Ok((0, 0))
     }
 }
 

--- a/src/capturable/win_ctx.rs
+++ b/src/capturable/win_ctx.rs
@@ -1,0 +1,93 @@
+use std::mem::zeroed;
+use std::{mem, ptr};
+use winapi::shared::dxgi::{
+    CreateDXGIFactory1, IDXGIAdapter1, IDXGIFactory1, IDXGIOutput, IID_IDXGIFactory1,
+    DXGI_OUTPUT_DESC,
+};
+
+use winapi::shared::windef::*;
+use winapi::shared::winerror::*;
+use winapi::um::winuser::*;
+use wio::com::ComPtr;
+
+use super::captrs_capture::CaptrsCapturable;
+
+// from https://github.com/bryal/dxgcap-rs/blob/009b746d1c19c4c10921dd469eaee483db6aa002/src/lib.r
+fn hr_failed(hr: HRESULT) -> bool {
+    hr < 0
+}
+
+fn create_dxgi_factory_1() -> ComPtr<IDXGIFactory1> {
+    unsafe {
+        let mut factory = ptr::null_mut();
+        let hr = CreateDXGIFactory1(&IID_IDXGIFactory1, &mut factory);
+        if hr_failed(hr) {
+            panic!("Failed to create DXGIFactory1, {:x}", hr)
+        } else {
+            ComPtr::from_raw(factory as *mut IDXGIFactory1)
+        }
+    }
+}
+
+fn get_adapter_outputs(adapter: &IDXGIAdapter1) -> Vec<ComPtr<IDXGIOutput>> {
+    let mut outputs = Vec::new();
+    for i in 0.. {
+        unsafe {
+            let mut output = ptr::null_mut();
+            if hr_failed(adapter.EnumOutputs(i, &mut output)) {
+                break;
+            } else {
+                let mut out_desc = zeroed();
+                (*output).GetDesc(&mut out_desc);
+                if out_desc.AttachedToDesktop != 0 {
+                    outputs.push(ComPtr::from_raw(output))
+                } else {
+                    break;
+                }
+            }
+        }
+    }
+    outputs
+}
+
+#[derive(Clone)]
+pub struct WinCtx {
+    outputs: Vec<RECT>,
+    union_rect: RECT,
+}
+
+impl WinCtx {
+    pub fn new() -> WinCtx {
+        let mut rects: Vec<RECT> = Vec::new();
+        let mut union: RECT;
+        unsafe {
+            union = mem::zeroed();
+            let factory = create_dxgi_factory_1();
+            let mut adapter = ptr::null_mut();
+            if factory.EnumAdapters1(0, &mut adapter) != DXGI_ERROR_NOT_FOUND {
+                let adp = ComPtr::from_raw(adapter);
+                let outputs = get_adapter_outputs(&adp);
+                for o in outputs {
+                    let mut desc: DXGI_OUTPUT_DESC = mem::zeroed();
+                    o.GetDesc(ptr::addr_of_mut!(desc));
+                    rects.push(desc.DesktopCoordinates);
+                    UnionRect(
+                        ptr::addr_of_mut!(union),
+                        ptr::addr_of!(union),
+                        ptr::addr_of!(desc.DesktopCoordinates),
+                    );
+                }
+            }
+        }
+        WinCtx {
+            outputs: rects,
+            union_rect: union,
+        }
+    }
+    pub fn get_outputs(&self) -> &Vec<RECT> {
+        &self.outputs
+    }
+    pub fn get_union_rect(&self) -> &RECT {
+        &self.union_rect
+    }
+}

--- a/src/capturable/win_ctx.rs
+++ b/src/capturable/win_ctx.rs
@@ -10,8 +10,6 @@ use winapi::shared::winerror::*;
 use winapi::um::winuser::*;
 use wio::com::ComPtr;
 
-use super::captrs_capture::CaptrsCapturable;
-
 // from https://github.com/bryal/dxgcap-rs/blob/009b746d1c19c4c10921dd469eaee483db6aa002/src/lib.r
 fn hr_failed(hr: HRESULT) -> bool {
     hr < 0

--- a/src/capturable/win_ctx.rs
+++ b/src/capturable/win_ctx.rs
@@ -50,13 +50,13 @@ fn get_adapter_outputs(adapter: &IDXGIAdapter1) -> Vec<ComPtr<IDXGIOutput>> {
 
 #[derive(Clone)]
 pub struct WinCtx {
-    outputs: Vec<RECT>,
+    outputs: Vec<DXGI_OUTPUT_DESC>,
     union_rect: RECT,
 }
 
 impl WinCtx {
     pub fn new() -> WinCtx {
-        let mut rects: Vec<RECT> = Vec::new();
+        let mut desktops: Vec<DXGI_OUTPUT_DESC> = Vec::new();
         let mut union: RECT;
         unsafe {
             union = mem::zeroed();
@@ -68,7 +68,7 @@ impl WinCtx {
                 for o in outputs {
                     let mut desc: DXGI_OUTPUT_DESC = mem::zeroed();
                     o.GetDesc(ptr::addr_of_mut!(desc));
-                    rects.push(desc.DesktopCoordinates);
+                    desktops.push(desc);
                     UnionRect(
                         ptr::addr_of_mut!(union),
                         ptr::addr_of!(union),
@@ -78,11 +78,11 @@ impl WinCtx {
             }
         }
         WinCtx {
-            outputs: rects,
+            outputs: desktops,
             union_rect: union,
         }
     }
-    pub fn get_outputs(&self) -> &Vec<RECT> {
+    pub fn get_outputs(&self) -> &Vec<DXGI_OUTPUT_DESC> {
         &self.outputs
     }
     pub fn get_union_rect(&self) -> &RECT {

--- a/src/capturable/x11.rs
+++ b/src/capturable/x11.rs
@@ -1,4 +1,4 @@
-use crate::capturable::{Capturable, Recorder};
+use crate::capturable::{Capturable, Geometry, Recorder};
 use crate::cerror::CError;
 use crate::video::PixelProvider;
 use std::ffi::{CStr, CString};

--- a/src/capturable/x11.rs
+++ b/src/capturable/x11.rs
@@ -94,7 +94,7 @@ impl Capturable for X11Capturable {
         }
     }
 
-    fn geometry(&self) -> Result<(Geometry), Box<dyn Error>> {
+    fn geometry(&self) -> Result<Geometry, Box<dyn Error>> {
         let mut x: c_float = 0.0;
         let mut y: c_float = 0.0;
         let mut width: c_float = 0.0;

--- a/src/capturable/x11.rs
+++ b/src/capturable/x11.rs
@@ -136,6 +136,14 @@ impl Capturable for X11Capturable {
             Err(err) => Err(Box::new(err)),
         }
     }
+
+    fn geometry(&self) -> Result<(u32, u32), Box<dyn Error>> {
+        Ok((0, 0))
+    }
+
+    fn geometry_offset(&self) -> Result<(i32, i32), Box<dyn Error>> {
+        Ok((0, 0))
+    }
 }
 
 impl fmt::Display for X11Capturable {

--- a/src/capturable/x11.rs
+++ b/src/capturable/x11.rs
@@ -94,7 +94,7 @@ impl Capturable for X11Capturable {
         }
     }
 
-    fn geometry_relative(&self) -> Result<(f64, f64, f64, f64), Box<dyn Error>> {
+    fn geometry(&self) -> Result<(Geometry), Box<dyn Error>> {
         let mut x: c_float = 0.0;
         let mut y: c_float = 0.0;
         let mut width: c_float = 0.0;
@@ -115,7 +115,12 @@ impl Capturable for X11Capturable {
         if err.is_err() {
             return Err(Box::new(err));
         }
-        Ok((x.into(), y.into(), width.into(), height.into()))
+        Ok(Geometry::Relative(
+            x.into(),
+            y.into(),
+            width.into(),
+            height.into(),
+        ))
     }
 
     fn before_input(&mut self) -> Result<(), Box<dyn Error>> {
@@ -135,14 +140,6 @@ impl Capturable for X11Capturable {
             Ok(recorder) => Ok(Box::new(recorder)),
             Err(err) => Err(Box::new(err)),
         }
-    }
-
-    fn geometry(&self) -> Result<(u32, u32), Box<dyn Error>> {
-        Ok((0, 0))
-    }
-
-    fn geometry_offset(&self) -> Result<(i32, i32), Box<dyn Error>> {
-        Ok((0, 0))
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -40,6 +40,9 @@ pub struct Config {
     )]
     #[serde(default)]
     pub try_mediafoundation: bool,
+    #[structopt(long, help = "If device is connected Wylus is automatically launched on Android")]
+    #[serde(default)]
+    pub adb_start: bool,
     #[structopt(long, help = "Start Weylus server immediately on program start.")]
     #[serde(default)]
     pub auto_start: bool,

--- a/src/input/autopilot_device.rs
+++ b/src/input/autopilot_device.rs
@@ -8,7 +8,7 @@ use tracing::warn;
 use crate::input::device::{InputDevice, InputDeviceType};
 use crate::protocol::{Button, KeyboardEvent, KeyboardEventType, PointerEvent, WheelEvent};
 
-use crate::capturable::Capturable;
+use crate::capturable::{Capturable, Geometry};
 
 pub struct AutoPilotDevice {
     capturable: Box<dyn Capturable>,
@@ -37,12 +37,15 @@ impl InputDevice for AutoPilotDevice {
             warn!("Failed to activate window, sending no input ({})", err);
             return;
         }
-        let geometry = self.capturable.geometry_relative();
+        let geometry = self.capturable.geometry();
         if let Err(err) = geometry {
             warn!("Failed to get window geometry, sending no input ({})", err);
             return;
         }
-        let (x_rel, y_rel, width_rel, height_rel) = geometry.unwrap();
+        let (x_rel, y_rel, width_rel, height_rel) = match geometry.unwrap() {
+            Geometry::Relative(x, y, width, height) => (x, y, width, height),
+            _ => unreachable!(),
+        };
         #[cfg(not(target_os = "macos"))]
         let Size { width, height } = screen_size();
         #[cfg(target_os = "macos")]

--- a/src/input/autopilot_device.rs
+++ b/src/input/autopilot_device.rs
@@ -3,20 +3,32 @@ use autopilot::mouse;
 use autopilot::mouse::ScrollDirection;
 use autopilot::screen::size as screen_size;
 
+use winapi::shared::windef::{HWND, POINT};
+use winapi::um::winuser::*;
+
 use tracing::warn;
 
 use crate::input::device::{InputDevice, InputDeviceType};
-use crate::protocol::{Button, KeyboardEvent, KeyboardEventType, PointerEvent, WheelEvent};
+use crate::protocol::{
+    Button, KeyboardEvent, KeyboardEventType, PointerEvent, PointerEventType, PointerType,
+    WheelEvent,
+};
 
 use crate::capturable::Capturable;
 
 pub struct AutoPilotDevice {
     capturable: Box<dyn Capturable>,
+    pointer_device_handle: *mut HSYNTHETICPOINTERDEVICE__,
 }
 
 impl AutoPilotDevice {
     pub fn new(capturable: Box<dyn Capturable>) -> Self {
-        Self { capturable }
+        unsafe {
+            Self {
+                capturable,
+                pointer_device_handle: CreateSyntheticPointerDevice(PT_PEN, 1, 1),
+            }
+        }
     }
 }
 
@@ -53,23 +65,99 @@ impl InputDevice for AutoPilotDevice {
                 return;
             }
         };
-        if let Err(err) = mouse::move_to(autopilot::geometry::Point::new(
-            (event.x * width_rel + x_rel) * width,
-            (event.y * height_rel + y_rel) * height,
-        )) {
-            warn!("Could not move mouse: {}", err);
-        }
-        match event.button {
-            Button::PRIMARY => {
-                mouse::toggle(mouse::Button::Left, event.buttons.contains(event.button))
+        let (x, y) = (
+            ((event.x * width_rel + x_rel) * width) as i32,
+            ((event.y * height_rel + y_rel) * height) as i32,
+        );
+        match event.pointer_type {
+            PointerType::Pen => {
+                unsafe {
+                    let mut pointer_type_info = POINTER_TYPE_INFO {
+                        type_: PT_PEN,
+                        u: std::mem::zeroed(),
+                    };
+                    //| POINTER_FLAG_FIRSTBUTTON
+                    let pointer_flags;
+                    let button_change_type;
+                    match event.event_type {
+                        PointerEventType::DOWN => {
+                            pointer_flags = POINTER_FLAG_INRANGE
+                                | POINTER_FLAG_INCONTACT
+                                | POINTER_FLAG_PRIMARY
+                                | POINTER_FLAG_DOWN;
+                            button_change_type = POINTER_CHANGE_FIRSTBUTTON_DOWN;
+                        }
+
+                        PointerEventType::UP => {
+                            pointer_flags = POINTER_FLAG_PRIMARY | POINTER_FLAG_UP;
+                            button_change_type = POINTER_CHANGE_FIRSTBUTTON_UP;
+                        }
+                        PointerEventType::MOVE => {
+                            pointer_flags = POINTER_FLAG_INRANGE
+                                | POINTER_FLAG_INCONTACT
+                                | POINTER_FLAG_PRIMARY;
+                            button_change_type = POINTER_CHANGE_NONE;
+                        }
+
+                        PointerEventType::CANCEL => {
+                            pointer_flags = POINTER_FLAG_PRIMARY | POINTER_FLAG_CANCELED;
+                            button_change_type = POINTER_CHANGE_NONE;
+                        }
+                    };
+                    *pointer_type_info.u.penInfo_mut() = POINTER_PEN_INFO {
+                        pointerInfo: POINTER_INFO {
+                            pointerType: PT_PEN,
+                            pointerId: event.pointer_id as u32,
+                            frameId: 0,
+                            pointerFlags: pointer_flags,
+                            sourceDevice: 0 as *mut winapi::ctypes::c_void, //maybe use syntheticPointerDeviceHandle here but works with 0
+                            hwndTarget: 0 as HWND,
+                            ptPixelLocation: POINT { x: x, y: y },
+                            ptHimetricLocation: POINT { x: 0, y: 0 },
+                            ptPixelLocationRaw: POINT { x: x, y: y },
+                            ptHimetricLocationRaw: POINT { x: 0, y: 0 },
+                            dwTime: 0,
+                            historyCount: 1,
+                            InputData: 0,
+                            dwKeyStates: 0,
+                            PerformanceCount: 0,
+                            ButtonChangeType: button_change_type,
+                        },
+                        penFlags: PEN_FLAG_NONE,
+                        penMask: PEN_MASK_PRESSURE
+                            | PEN_MASK_ROTATION
+                            | PEN_MASK_TILT_X
+                            | PEN_MASK_TILT_Y,
+                        pressure: (event.pressure * 100f64) as u32,
+                        rotation: event.twist as u32,
+                        tiltX: event.tilt_x,
+                        tiltY: event.tilt_y,
+                    };
+                    InjectSyntheticPointerInput(self.pointer_device_handle, &pointer_type_info, 1);
+                }
             }
-            Button::AUXILARY => {
-                mouse::toggle(mouse::Button::Middle, event.buttons.contains(event.button))
+            PointerType::Mouse => {
+                if let Err(err) = mouse::move_to(autopilot::geometry::Point::new(
+                    (event.x * width_rel + x_rel) * width,
+                    (event.y * height_rel + y_rel) * height,
+                )) {
+                    warn!("Could not move mouse: {}", err);
+                }
+                match event.button {
+                    Button::PRIMARY => {
+                        mouse::toggle(mouse::Button::Left, event.buttons.contains(event.button))
+                    }
+                    Button::AUXILARY => {
+                        mouse::toggle(mouse::Button::Middle, event.buttons.contains(event.button))
+                    }
+                    Button::SECONDARY => {
+                        mouse::toggle(mouse::Button::Right, event.buttons.contains(event.button))
+                    }
+                    _ => (),
+                }
             }
-            Button::SECONDARY => {
-                mouse::toggle(mouse::Button::Right, event.buttons.contains(event.button))
-            }
-            _ => (),
+            PointerType::Touch => todo!(),
+            PointerType::Unknown => todo!(),
         }
     }
 

--- a/src/input/autopilot_device.rs
+++ b/src/input/autopilot_device.rs
@@ -3,32 +3,20 @@ use autopilot::mouse;
 use autopilot::mouse::ScrollDirection;
 use autopilot::screen::size as screen_size;
 
-use winapi::shared::windef::{HWND, POINT};
-use winapi::um::winuser::*;
-
 use tracing::warn;
 
 use crate::input::device::{InputDevice, InputDeviceType};
-use crate::protocol::{
-    Button, KeyboardEvent, KeyboardEventType, PointerEvent, PointerEventType, PointerType,
-    WheelEvent,
-};
+use crate::protocol::{Button, KeyboardEvent, KeyboardEventType, PointerEvent, WheelEvent};
 
 use crate::capturable::Capturable;
 
 pub struct AutoPilotDevice {
     capturable: Box<dyn Capturable>,
-    pointer_device_handle: *mut HSYNTHETICPOINTERDEVICE__,
 }
 
 impl AutoPilotDevice {
     pub fn new(capturable: Box<dyn Capturable>) -> Self {
-        unsafe {
-            Self {
-                capturable,
-                pointer_device_handle: CreateSyntheticPointerDevice(PT_PEN, 1, 1),
-            }
-        }
+        Self { capturable }
     }
 }
 
@@ -65,99 +53,23 @@ impl InputDevice for AutoPilotDevice {
                 return;
             }
         };
-        let (x, y) = (
-            ((event.x * width_rel + x_rel) * width) as i32,
-            ((event.y * height_rel + y_rel) * height) as i32,
-        );
-        match event.pointer_type {
-            PointerType::Pen => {
-                unsafe {
-                    let mut pointer_type_info = POINTER_TYPE_INFO {
-                        type_: PT_PEN,
-                        u: std::mem::zeroed(),
-                    };
-                    //| POINTER_FLAG_FIRSTBUTTON
-                    let pointer_flags;
-                    let button_change_type;
-                    match event.event_type {
-                        PointerEventType::DOWN => {
-                            pointer_flags = POINTER_FLAG_INRANGE
-                                | POINTER_FLAG_INCONTACT
-                                | POINTER_FLAG_PRIMARY
-                                | POINTER_FLAG_DOWN;
-                            button_change_type = POINTER_CHANGE_FIRSTBUTTON_DOWN;
-                        }
-
-                        PointerEventType::UP => {
-                            pointer_flags = POINTER_FLAG_PRIMARY | POINTER_FLAG_UP;
-                            button_change_type = POINTER_CHANGE_FIRSTBUTTON_UP;
-                        }
-                        PointerEventType::MOVE => {
-                            pointer_flags = POINTER_FLAG_INRANGE
-                                | POINTER_FLAG_INCONTACT
-                                | POINTER_FLAG_PRIMARY;
-                            button_change_type = POINTER_CHANGE_NONE;
-                        }
-
-                        PointerEventType::CANCEL => {
-                            pointer_flags = POINTER_FLAG_PRIMARY | POINTER_FLAG_CANCELED;
-                            button_change_type = POINTER_CHANGE_NONE;
-                        }
-                    };
-                    *pointer_type_info.u.penInfo_mut() = POINTER_PEN_INFO {
-                        pointerInfo: POINTER_INFO {
-                            pointerType: PT_PEN,
-                            pointerId: event.pointer_id as u32,
-                            frameId: 0,
-                            pointerFlags: pointer_flags,
-                            sourceDevice: 0 as *mut winapi::ctypes::c_void, //maybe use syntheticPointerDeviceHandle here but works with 0
-                            hwndTarget: 0 as HWND,
-                            ptPixelLocation: POINT { x: x, y: y },
-                            ptHimetricLocation: POINT { x: 0, y: 0 },
-                            ptPixelLocationRaw: POINT { x: x, y: y },
-                            ptHimetricLocationRaw: POINT { x: 0, y: 0 },
-                            dwTime: 0,
-                            historyCount: 1,
-                            InputData: 0,
-                            dwKeyStates: 0,
-                            PerformanceCount: 0,
-                            ButtonChangeType: button_change_type,
-                        },
-                        penFlags: PEN_FLAG_NONE,
-                        penMask: PEN_MASK_PRESSURE
-                            | PEN_MASK_ROTATION
-                            | PEN_MASK_TILT_X
-                            | PEN_MASK_TILT_Y,
-                        pressure: (event.pressure * 100f64) as u32,
-                        rotation: event.twist as u32,
-                        tiltX: event.tilt_x,
-                        tiltY: event.tilt_y,
-                    };
-                    InjectSyntheticPointerInput(self.pointer_device_handle, &pointer_type_info, 1);
-                }
+        if let Err(err) = mouse::move_to(autopilot::geometry::Point::new(
+            (event.x * width_rel + x_rel) * width,
+            (event.y * height_rel + y_rel) * height,
+        )) {
+            warn!("Could not move mouse: {}", err);
+        }
+        match event.button {
+            Button::PRIMARY => {
+                mouse::toggle(mouse::Button::Left, event.buttons.contains(event.button))
             }
-            PointerType::Mouse => {
-                if let Err(err) = mouse::move_to(autopilot::geometry::Point::new(
-                    (event.x * width_rel + x_rel) * width,
-                    (event.y * height_rel + y_rel) * height,
-                )) {
-                    warn!("Could not move mouse: {}", err);
-                }
-                match event.button {
-                    Button::PRIMARY => {
-                        mouse::toggle(mouse::Button::Left, event.buttons.contains(event.button))
-                    }
-                    Button::AUXILARY => {
-                        mouse::toggle(mouse::Button::Middle, event.buttons.contains(event.button))
-                    }
-                    Button::SECONDARY => {
-                        mouse::toggle(mouse::Button::Right, event.buttons.contains(event.button))
-                    }
-                    _ => (),
-                }
+            Button::AUXILARY => {
+                mouse::toggle(mouse::Button::Middle, event.buttons.contains(event.button))
             }
-            PointerType::Touch => todo!(),
-            PointerType::Unknown => todo!(),
+            Button::SECONDARY => {
+                mouse::toggle(mouse::Button::Right, event.buttons.contains(event.button))
+            }
+            _ => (),
         }
     }
 

--- a/src/input/autopilot_device_win.rs
+++ b/src/input/autopilot_device_win.rs
@@ -57,10 +57,11 @@ impl InputDevice for WindowsInput {
             return;
         }
         let (x_rel, y_rel, width_rel, height_rel) = geometry.unwrap();
-        let Size { width, height } = screen_size();
+        let (width, height) = self.capturable.geometry().unwrap();
+        let (offset_x, offset_y) = self.capturable.geometry_offset().unwrap();
         let (x, y) = (
-            ((event.x * width_rel + x_rel) * width) as i32,
-            ((event.y * height_rel + y_rel) * height) as i32,
+            ((event.x * width_rel + x_rel) * width as f64) as i32 + offset_x,
+            ((event.y * height_rel + y_rel) * height as f64) as i32 + offset_y,
         );
         let mut pointer_type_info = POINTER_TYPE_INFO {
             type_: PT_PEN,
@@ -170,8 +171,8 @@ impl InputDevice for WindowsInput {
             }
             PointerType::Mouse => {
                 if let Err(err) = mouse::move_to(autopilot::geometry::Point::new(
-                    (event.x * width_rel + x_rel) * width,
-                    (event.y * height_rel + y_rel) * height,
+                    (event.x * width_rel + x_rel) * width as f64,
+                    (event.y * height_rel + y_rel) * height as f64,
                 )) {
                     warn!("Could not move mouse: {}", err);
                 }

--- a/src/input/autopilot_device_win.rs
+++ b/src/input/autopilot_device_win.rs
@@ -107,7 +107,7 @@ impl InputDevice for WindowsInput {
                             | PEN_MASK_ROTATION
                             | PEN_MASK_TILT_X
                             | PEN_MASK_TILT_Y,
-                        pressure: (event.pressure * 100f64) as u32,
+                        pressure: (event.pressure * 1024f64) as u32,
                         rotation: event.twist as u32,
                         tiltX: event.tilt_x,
                         tiltY: event.tilt_y,

--- a/src/input/autopilot_device_win.rs
+++ b/src/input/autopilot_device_win.rs
@@ -54,24 +54,25 @@ impl InputDevice for WindowsInput {
             (event.x * width as f64) as i32 + offset_x,
             (event.y * height as f64) as i32 + offset_y,
         );
-        let button_change_type = match event.buttons {
-            Button::PRIMARY => POINTER_CHANGE_FIRSTBUTTON_DOWN,
-            Button::SECONDARY => POINTER_CHANGE_SECONDBUTTON_DOWN,
-            Button::AUXILARY => POINTER_CHANGE_THIRDBUTTON_DOWN,
-            Button::NONE => POINTER_CHANGE_NONE,
-            _ => POINTER_CHANGE_NONE,
-        };
         let mut pointer_flags = match event.event_type {
             PointerEventType::DOWN => {
                 POINTER_FLAG_INRANGE | POINTER_FLAG_INCONTACT | POINTER_FLAG_DOWN
             }
-            PointerEventType::MOVE => {
-                POINTER_FLAG_INRANGE | POINTER_FLAG_INCONTACT | POINTER_FLAG_UPDATE
-            }
+            PointerEventType::MOVE => POINTER_FLAG_INRANGE | POINTER_FLAG_UPDATE,
             PointerEventType::UP => POINTER_FLAG_UP,
             PointerEventType::CANCEL => {
                 POINTER_FLAG_INRANGE | POINTER_FLAG_UPDATE | POINTER_FLAG_CANCELED
             }
+        };
+        let button_change_type = match event.buttons {
+            Button::PRIMARY => {
+                pointer_flags |= POINTER_FLAG_INCONTACT;
+                POINTER_CHANGE_FIRSTBUTTON_DOWN
+            }
+            Button::SECONDARY => POINTER_CHANGE_SECONDBUTTON_DOWN,
+            Button::AUXILARY => POINTER_CHANGE_THIRDBUTTON_DOWN,
+            Button::NONE => POINTER_CHANGE_NONE,
+            _ => POINTER_CHANGE_NONE,
         };
         if event.is_primary {
             pointer_flags |= POINTER_FLAG_PRIMARY;

--- a/src/input/autopilot_device_win.rs
+++ b/src/input/autopilot_device_win.rs
@@ -50,10 +50,6 @@ impl InputDevice for WindowsInput {
                 }
                 _ => unreachable!(),
             };
-        print!(
-            "offset_x {} offset_y {} width {} height {}",
-            offset_x, offset_y, width, height
-        );
         let (x, y) = (
             (event.x * width as f64) as i32 + offset_x,
             (event.y * height as f64) as i32 + offset_y,
@@ -120,7 +116,6 @@ impl InputDevice for WindowsInput {
                 }
             }
             PointerType::Touch => {
-                println!("touch event\n\n");
                 unsafe {
                     let mut pointer_type_info = POINTER_TYPE_INFO {
                         type_: PT_TOUCH,
@@ -184,7 +179,6 @@ impl InputDevice for WindowsInput {
                     }
                 }
                 unsafe { mouse_event(dw_flags, 0 as u32, 0 as u32, 0, 0) };
-                print!("mouse event {} {}", screen_x, screen_y);
             }
             PointerType::Unknown => todo!(),
         }

--- a/src/input/autopilot_device_win.rs
+++ b/src/input/autopilot_device_win.rs
@@ -1,7 +1,5 @@
-use autopilot::geometry::Size;
 use autopilot::mouse;
 use autopilot::mouse::ScrollDirection;
-use autopilot::screen::size as screen_size;
 
 use winapi::shared::windef::{HWND, POINT, RECT};
 use winapi::um::winuser::*;

--- a/src/input/autopilot_device_win.rs
+++ b/src/input/autopilot_device_win.rs
@@ -26,7 +26,7 @@ impl WindowsInput {
         unsafe {
             Self {
                 capturable: capturable.clone(),
-                autopilot_device: AutoPilotDevice::new(capturable.clone()),
+                autopilot_device: AutoPilotDevice::new(capturable),
                 pointer_device_handle: CreateSyntheticPointerDevice(PT_PEN, 1, 1),
                 touch_device_handle: CreateSyntheticPointerDevice(PT_TOUCH, 5, 1),
             }

--- a/src/input/autopilot_device_win.rs
+++ b/src/input/autopilot_device_win.rs
@@ -44,9 +44,6 @@ impl InputDevice for WindowsInput {
     }
 
     fn send_pointer_event(&mut self, event: &PointerEvent) {
-        if !event.is_primary {
-            return;
-        }
         if let Err(err) = self.capturable.before_input() {
             warn!("Failed to activate window, sending no input ({})", err);
             return;

--- a/src/input/autopilot_device_win.rs
+++ b/src/input/autopilot_device_win.rs
@@ -1,0 +1,284 @@
+use autopilot::geometry::Size;
+use autopilot::mouse;
+use autopilot::mouse::ScrollDirection;
+use autopilot::screen::size as screen_size;
+
+use winapi::shared::windef::{HWND, POINT, RECT};
+use winapi::um::winuser::*;
+
+use tracing::warn;
+
+use crate::input::device::{InputDevice, InputDeviceType};
+use crate::protocol::{
+    Button, KeyboardEvent, KeyboardEventType, PointerEvent, PointerEventType, PointerType,
+    WheelEvent,
+};
+
+use crate::capturable::Capturable;
+
+pub struct WindowsInput {
+    capturable: Box<dyn Capturable>,
+    pointer_device_handle: *mut HSYNTHETICPOINTERDEVICE__,
+    touch_device_handle: *mut HSYNTHETICPOINTERDEVICE__,
+}
+
+impl WindowsInput {
+    pub fn new(capturable: Box<dyn Capturable>) -> Self {
+        unsafe {
+            Self {
+                capturable,
+                pointer_device_handle: CreateSyntheticPointerDevice(PT_PEN, 1, 1),
+                touch_device_handle: CreateSyntheticPointerDevice(PT_TOUCH, 5, 1),
+            }
+        }
+    }
+}
+
+impl InputDevice for WindowsInput {
+    fn send_wheel_event(&mut self, event: &WheelEvent) {
+        match event.dy {
+            1..=i32::MAX => mouse::scroll(ScrollDirection::Up, 1),
+            i32::MIN..=-1 => mouse::scroll(ScrollDirection::Down, 1),
+            0 => {}
+        }
+    }
+
+    fn send_pointer_event(&mut self, event: &PointerEvent) {
+        if !event.is_primary {
+            return;
+        }
+        if let Err(err) = self.capturable.before_input() {
+            warn!("Failed to activate window, sending no input ({})", err);
+            return;
+        }
+        let geometry = self.capturable.geometry_relative();
+        if let Err(err) = geometry {
+            warn!("Failed to get window geometry, sending no input ({})", err);
+            return;
+        }
+        let (x_rel, y_rel, width_rel, height_rel) = geometry.unwrap();
+        let Size { width, height } = screen_size();
+        let (x, y) = (
+            ((event.x * width_rel + x_rel) * width) as i32,
+            ((event.y * height_rel + y_rel) * height) as i32,
+        );
+        let mut pointer_type_info = POINTER_TYPE_INFO {
+            type_: PT_PEN,
+            u: unsafe { std::mem::zeroed() },
+        };
+        let pointer_flags;
+        let button_change_type;
+        match event.event_type {
+            PointerEventType::DOWN => {
+                pointer_flags = POINTER_FLAG_INRANGE
+                    | POINTER_FLAG_INCONTACT
+                    | POINTER_FLAG_PRIMARY
+                    | POINTER_FLAG_DOWN;
+                button_change_type = POINTER_CHANGE_FIRSTBUTTON_DOWN;
+            }
+
+            PointerEventType::UP => {
+                pointer_flags = POINTER_FLAG_PRIMARY | POINTER_FLAG_UP;
+                button_change_type = POINTER_CHANGE_FIRSTBUTTON_UP;
+            }
+            PointerEventType::MOVE => {
+                pointer_flags =
+                    POINTER_FLAG_INRANGE | POINTER_FLAG_INCONTACT | POINTER_FLAG_PRIMARY;
+                button_change_type = POINTER_CHANGE_NONE;
+            }
+
+            PointerEventType::CANCEL => {
+                pointer_flags = POINTER_FLAG_PRIMARY | POINTER_FLAG_CANCELED;
+                button_change_type = POINTER_CHANGE_NONE;
+            }
+        };
+        match event.pointer_type {
+            PointerType::Pen => {
+                unsafe {
+                    *pointer_type_info.u.penInfo_mut() = POINTER_PEN_INFO {
+                        pointerInfo: POINTER_INFO {
+                            pointerType: PT_PEN,
+                            pointerId: event.pointer_id as u32,
+                            frameId: 0,
+                            pointerFlags: pointer_flags,
+                            sourceDevice: 0 as *mut winapi::ctypes::c_void, //maybe use syntheticPointerDeviceHandle here but works with 0
+                            hwndTarget: 0 as HWND,
+                            ptPixelLocation: POINT { x: x, y: y },
+                            ptHimetricLocation: POINT { x: 0, y: 0 },
+                            ptPixelLocationRaw: POINT { x: x, y: y },
+                            ptHimetricLocationRaw: POINT { x: 0, y: 0 },
+                            dwTime: 0,
+                            historyCount: 1,
+                            InputData: 0,
+                            dwKeyStates: 0,
+                            PerformanceCount: 0,
+                            ButtonChangeType: button_change_type,
+                        },
+                        penFlags: PEN_FLAG_NONE,
+                        penMask: PEN_MASK_PRESSURE
+                            | PEN_MASK_ROTATION
+                            | PEN_MASK_TILT_X
+                            | PEN_MASK_TILT_Y,
+                        pressure: (event.pressure * 100f64) as u32,
+                        rotation: event.twist as u32,
+                        tiltX: event.tilt_x,
+                        tiltY: event.tilt_y,
+                    };
+                    InjectSyntheticPointerInput(self.pointer_device_handle, &pointer_type_info, 1);
+                }
+            }
+            PointerType::Touch => {
+                unsafe {
+                    *pointer_type_info.u.touchInfo_mut() = POINTER_TOUCH_INFO {
+                        pointerInfo: POINTER_INFO {
+                            pointerType: PT_TOUCH,
+                            pointerId: event.pointer_id as u32,
+                            frameId: 0,
+                            pointerFlags: pointer_flags,
+                            sourceDevice: 0 as *mut winapi::ctypes::c_void, //maybe use syntheticPointerDeviceHandle here but works with 0
+                            hwndTarget: 0 as HWND,
+                            ptPixelLocation: POINT { x: x, y: y },
+                            ptHimetricLocation: POINT { x: 0, y: 0 },
+                            ptPixelLocationRaw: POINT { x: x, y: y },
+                            ptHimetricLocationRaw: POINT { x: 0, y: 0 },
+                            dwTime: 0,
+                            historyCount: 1,
+                            InputData: 0,
+                            dwKeyStates: 0,
+                            PerformanceCount: 0,
+                            ButtonChangeType: button_change_type,
+                        },
+                        touchFlags: TOUCH_FLAG_NONE,
+                        touchMask: TOUCH_MASK_PRESSURE,
+                        orientation: 0,
+                        pressure: (event.pressure * 100f64) as u32,
+                        rcContact: RECT {
+                            left: x,
+                            top: y,
+                            right: x,
+                            bottom: y,
+                        },
+                        rcContactRaw: RECT {
+                            left: x,
+                            top: y,
+                            right: x,
+                            bottom: y,
+                        },
+                    };
+                    InjectSyntheticPointerInput(self.touch_device_handle, &pointer_type_info, 1);
+                }
+            }
+            PointerType::Mouse => {
+                if let Err(err) = mouse::move_to(autopilot::geometry::Point::new(
+                    (event.x * width_rel + x_rel) * width,
+                    (event.y * height_rel + y_rel) * height,
+                )) {
+                    warn!("Could not move mouse: {}", err);
+                }
+                match event.button {
+                    Button::PRIMARY => {
+                        mouse::toggle(mouse::Button::Left, event.buttons.contains(event.button))
+                    }
+                    Button::AUXILARY => {
+                        mouse::toggle(mouse::Button::Middle, event.buttons.contains(event.button))
+                    }
+                    Button::SECONDARY => {
+                        mouse::toggle(mouse::Button::Right, event.buttons.contains(event.button))
+                    }
+                    _ => (),
+                }
+            }
+            PointerType::Unknown => todo!(),
+        }
+    }
+
+    fn send_keyboard_event(&mut self, event: &KeyboardEvent) {
+        use autopilot::key::{Character, Code, KeyCode};
+
+        let state = match event.event_type {
+            KeyboardEventType::UP => false,
+            KeyboardEventType::DOWN => true,
+            // autopilot doesn't handle this, so just do nothing
+            KeyboardEventType::REPEAT => return,
+        };
+
+        fn map_key(code: &str) -> Option<KeyCode> {
+            match code {
+                "Escape" => Some(KeyCode::Escape),
+                "Enter" => Some(KeyCode::Return),
+                "Backspace" => Some(KeyCode::Backspace),
+                "Tab" => Some(KeyCode::Tab),
+                "Space" => Some(KeyCode::Space),
+                "CapsLock" => Some(KeyCode::CapsLock),
+                "F1" => Some(KeyCode::F1),
+                "F2" => Some(KeyCode::F2),
+                "F3" => Some(KeyCode::F3),
+                "F4" => Some(KeyCode::F4),
+                "F5" => Some(KeyCode::F5),
+                "F6" => Some(KeyCode::F6),
+                "F7" => Some(KeyCode::F7),
+                "F8" => Some(KeyCode::F8),
+                "F9" => Some(KeyCode::F9),
+                "F10" => Some(KeyCode::F10),
+                "F11" => Some(KeyCode::F11),
+                "F12" => Some(KeyCode::F12),
+                "F13" => Some(KeyCode::F13),
+                "F14" => Some(KeyCode::F14),
+                "F15" => Some(KeyCode::F15),
+                "F16" => Some(KeyCode::F16),
+                "F17" => Some(KeyCode::F17),
+                "F18" => Some(KeyCode::F18),
+                "F19" => Some(KeyCode::F19),
+                "F20" => Some(KeyCode::F20),
+                "F21" => Some(KeyCode::F21),
+                "F22" => Some(KeyCode::F22),
+                "F23" => Some(KeyCode::F23),
+                "F24" => Some(KeyCode::F24),
+                "Home" => Some(KeyCode::Home),
+                "ArrowUp" => Some(KeyCode::UpArrow),
+                "PageUp" => Some(KeyCode::PageUp),
+                "ArrowLeft" => Some(KeyCode::LeftArrow),
+                "ArrowRight" => Some(KeyCode::RightArrow),
+                "End" => Some(KeyCode::End),
+                "ArrowDown" => Some(KeyCode::DownArrow),
+                "PageDown" => Some(KeyCode::PageDown),
+                "Delete" => Some(KeyCode::Delete),
+                "ControlLeft" | "ControlRight" => Some(KeyCode::Control),
+                "AltLeft" | "AltRight" => Some(KeyCode::Alt),
+                "MetaLeft" | "MetaRight" => Some(KeyCode::Meta),
+                "ShiftLeft" | "ShiftRight" => Some(KeyCode::Shift),
+                _ => None,
+            }
+        }
+        let key = map_key(&event.code);
+        let mut flags = Vec::new();
+        if event.ctrl {
+            flags.push(autopilot::key::Flag::Control);
+        }
+        if event.alt {
+            flags.push(autopilot::key::Flag::Alt);
+        }
+        if event.meta {
+            flags.push(autopilot::key::Flag::Meta);
+        }
+        if event.shift {
+            flags.push(autopilot::key::Flag::Shift);
+        }
+        match key {
+            Some(key) => autopilot::key::toggle(&Code(key), state, &flags, 0),
+            None => {
+                for c in event.key.chars() {
+                    autopilot::key::toggle(&Character(c), state, &flags, 0);
+                }
+            }
+        }
+    }
+
+    fn set_capturable(&mut self, capturable: Box<dyn Capturable>) {
+        self.capturable = capturable;
+    }
+
+    fn device_type(&self) -> InputDeviceType {
+        InputDeviceType::WindowsInput
+    }
+}

--- a/src/input/device.rs
+++ b/src/input/device.rs
@@ -1,10 +1,11 @@
-use crate::protocol::{WheelEvent, PointerEvent, KeyboardEvent};
 use crate::capturable::Capturable;
+use crate::protocol::{KeyboardEvent, PointerEvent, WheelEvent};
 
 #[derive(PartialEq, Eq)]
 pub enum InputDeviceType {
     AutoPilotDevice,
     UInputDevice,
+    WindowsInput,
 }
 
 pub trait InputDevice {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1,8 +1,9 @@
-pub mod device;
 pub mod autopilot_device;
+pub mod autopilot_device_win;
+pub mod device;
 
+#[cfg(target_os = "linux")]
+pub mod uinput_device;
 #[cfg(target_os = "linux")]
 #[allow(dead_code)]
 pub mod uinput_keys;
-#[cfg(target_os = "linux")]
-pub mod uinput_device;

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1,6 +1,8 @@
 pub mod autopilot_device;
-pub mod autopilot_device_win;
 pub mod device;
+
+#[cfg(target_os = "windows")]
+pub mod autopilot_device_win;
 
 #[cfg(target_os = "linux")]
 pub mod uinput_device;

--- a/src/input/uinput_device.rs
+++ b/src/input/uinput_device.rs
@@ -3,7 +3,7 @@ use std::ffi::CString;
 use std::os::raw::{c_char, c_int};
 
 use crate::capturable::x11::X11Context;
-use crate::capturable::Capturable;
+use crate::capturable::{Capturable, Geometry};
 use crate::input::device::{InputDevice, InputDeviceType};
 use crate::protocol::{
     Button, KeyboardEvent, KeyboardEventType, KeyboardLocation, PointerEvent, PointerEventType,
@@ -278,12 +278,15 @@ impl InputDevice for UInputDevice {
             warn!("Failed to activate window, sending no input ({})", err);
             return;
         }
-        let geometry = self.capturable.geometry_relative();
+        let geometry = self.capturable.geometry();
         if let Err(err) = geometry {
             warn!("Failed to get window geometry, sending no input ({})", err);
             return;
         }
-        let (x, y, width, height) = geometry.unwrap();
+        let (x, y, width, height) = match geometry.unwrap() {
+            Geometry::Relative(x, y, width, height) => (x, y, width, height),
+            _ => unreachable!(),
+        };
         self.x = x;
         self.y = y;
         self.width = width;

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -21,12 +21,14 @@ pub enum MessageInbound {
     // rate. However, the server may drop a request if encoding is too slow.
     TryGetFrame,
     GetCapturableList,
+    GetFullscreen,
     Config(ClientConfiguration),
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 pub enum MessageOutbound {
     CapturableList(Vec<String>),
+    Fullscreen,
     NewVideo,
     ConfigOk,
     ConfigError(String),

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -13,7 +13,6 @@ use websocket::server::upgrade::{sync::Buffer as WsBuffer, WsUpgrade};
 use websocket::sync::Server;
 use websocket::{Message, OwnedMessage, WebSocketError};
 
-use crate::capturable::captrs_capture::CaptrsCapturable;
 use crate::capturable::{get_capturables, Capturable, Recorder};
 use crate::input::device::{InputDevice, InputDeviceType};
 use crate::protocol::{

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -459,6 +459,12 @@ impl WsHandler {
         self.send_msg(&MessageOutbound::CapturableList(windows));
     }
 
+    fn send_fullscreen(&mut self) {
+				//if config.adb_start {
+						self.send_msg(&MessageOutbound::Fullscreen);
+				//}
+    }
+
     fn setup(&mut self, config: ClientConfiguration) {
         let client_name_changed = if self.client_name != config.client_name {
             self.client_name = config.client_name;
@@ -573,6 +579,7 @@ impl WsHandler {
                             }
                             MessageInbound::TryGetFrame => self.queue_try_send_video_frame(),
                             MessageInbound::GetCapturableList => self.send_capturable_list(),
+                            MessageInbound::GetFullscreen => self.send_fullscreen(),
                             MessageInbound::Config(config) => self.setup(config),
                         }
                     }

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -510,10 +510,20 @@ impl WsHandler {
                 d.set_capturable(capturable.clone());
             }
 
-            #[cfg(not(target_os = "linux"))]
+            #[cfg(target_os = "macos")]
             if self.input_device.is_none() {
                 self.input_device = Some(Box::new(
                     crate::input::autopilot_device::AutoPilotDevice::new(capturable.clone()),
+                ));
+            } else {
+                self.input_device
+                    .as_mut()
+                    .map(|d| d.set_capturable(capturable.clone()));
+            }
+            #[cfg(target_os = "windows")]
+            if self.input_device.is_none() {
+                self.input_device = Some(Box::new(
+                    crate::input::autopilot_device_win::WindowsInput::new(capturable.clone()),
                 ));
             } else {
                 self.input_device

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -13,6 +13,7 @@ use websocket::server::upgrade::{sync::Buffer as WsBuffer, WsUpgrade};
 use websocket::sync::Server;
 use websocket::{Message, OwnedMessage, WebSocketError};
 
+use crate::capturable::captrs_capture::CaptrsCapturable;
 use crate::capturable::{get_capturables, Capturable, Recorder};
 use crate::input::device::{InputDevice, InputDeviceType};
 use crate::protocol::{


### PR DESCRIPTION
Hi @H-M-H 

To ease my daily usage I added an option to automatically forward the adb ports (adb must be in PATH) and to send an intent to Android to open the browser with the Weylus webpage on pressing Start.

This change is not finished. I am new to rust and progress is slow. More of the C/C++ guy.

Features I would like to add:
Automatically detect a new device / Hotplug support by scanning with adb devices in the background.
Automatically switch to Fullscreen mode if this is requested by the user. Of course a cheap option could also be to just remember the last state instead. 

What do you think?