### PR TITLE
Sort the window list case-insensitively

### DIFF
--- a/src/capturable/mod.rs
+++ b/src/capturable/mod.rs
@@ -132,5 +132,8 @@ pub fn get_capturables(
         }
     }
 
+    // sort the window list case-insensitively
+    capturables.sort_by(|a, b| a.name().to_lowercase().cmp(&b.name().to_lowercase()));
+
     capturables
 }


### PR DESCRIPTION
This makes it easier to find the target window if the window list is very long.