### PR TITLE
Modify write_video_packet prototype

### DIFF
--- a/lib/encode_video.c
+++ b/lib/encode_video.c
@@ -59,7 +59,7 @@ typedef struct VideoContext
 } VideoContext;
 
 // this is a rust function and lives in src/video.rs
-int write_video_packet(void* rust_ctx, uint8_t* buf, int buf_size);
+int write_video_packet(void* rust_ctx, const uint8_t* buf, int buf_size);
 
 #if defined(__clang__) || defined(__GNUC__)
 void log_callback(__attribute__((unused)) void* _ptr, int level, const char* fmt_orig, va_list args)


### PR DESCRIPTION
The prototype of `write_video_packet` did not match the [function definition](https://github.com/H-M-H/Weylus/blob/6411ba45260859f6ba44eb56ba86af4d5227eab3/src/video.rs#L31), resulting in a compiler error using `gcc (GCC) 14.1.1 20240522`. I updated the prototype to resolve the issue on my end.

This works on my system, but I'd like to know if there's a notable reason for not using the `const` keyword in this case (if I overlooked it).