### PR TITLE
Use Wayland if Available

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ clap = { version = "4.5.18", features = ["derive"] }
 clap_complete = "4.5.29"
 dirs = "^5.0"
 fastwebsockets = { version = "0.8.0", features = ["upgrade", "unstable-split"] }
-fltk = { version = "^1" }
+fltk = { version = "^1.3", features = ["use-wayland"] }
 fltk-theme = "0.7.3"
 handlebars = "^6.1"
 http-body-util = "0.1.2"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,8 @@ RUN apt-get update && \
    libxrender-dev libxfixes-dev libgl1-mesa-dev libglu1-mesa-dev libxtst-dev cmake git curl \
    software-properties-common zip libssl-dev libxrandr-dev libxcomposite-dev libxi-dev \
    gcc g++ autoconf libtool-bin libxv-dev libdrm-dev libpango1.0-dev pkg-config mingw-w64 \
-   libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libdbus-1-dev libxcb-dri3-dev clang
+   libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libdbus-1-dev libxcb-dri3-dev clang  \
+   libwayland-dev libxkbcommon-dev
 RUN apt-add-repository contrib
 RUN apt-add-repository non-free
 RUN apt-get update && apt-get install -y nvidia-cuda-dev

--- a/docker/Dockerfile_alpine
+++ b/docker/Dockerfile_alpine
@@ -4,7 +4,8 @@ ENV RUSTUP_HOME="/usr/local/rustup" CARGO_HOME="/usr/local/cargo" PATH="/usr/loc
 RUN apk add --no-cache libx11-dev libxext-dev libxft-dev libxinerama-dev libxcursor-dev \
     libxrender-dev libxfixes-dev libxtst-dev libxrandr-dev libxcomposite-dev libxi-dev libxv-dev \
     autoconf libtool pkgconfig libdrm-dev pango-dev gst-plugins-base-dev gstreamer-dev dbus-libs \
-    dbus-dev cmake build-base nasm npm ffmpeg-dev libva-dev curl git bash automake tar clang
+    dbus-dev cmake build-base nasm npm ffmpeg-dev libva-dev curl git bash automake tar clang \
+    wayland-dev libxkbcommon-dev
 
 RUN npm install --global typescript
 


### PR DESCRIPTION
This make linux builds hybird wayland/x11 instead of them being x11 only currently, with the slight downside of requiring wayland for building (not a problem for CI, and I think the amount of people who are building from source on x11 only systems is small).

See this issue for more detail: https://github.com/fltk-rs/fltk-rs/issues/1602

Fixes #3.