### PR TITLE
Fix ios video rendering

### DIFF
--- a/ts/lib.ts
+++ b/ts/lib.ts
@@ -1083,6 +1083,7 @@ function init() {
         settings.send_server_config();
     }
     video.controls = false;
+    video.disableRemotePlayback = true;
     video.onloadeddata = () => stretch_video();
     let is_connected = false;
     handle_messages(webSocket, video, () => {


### PR DESCRIPTION
enable video.disableRemotePlayback in lib.js
not sure if this is for all ios devices but this fixed rendering on IOS 26.0.1 on an apple iPhone 16 Pro