### PR TITLE
Add customizable touchpad mode with relative pointer input

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -83,11 +83,35 @@ full screen mode (on iOS/iPadOS this needs to be done with Safari). If you are n
 there is a button to toggle full screen mode.
 
 ### Touchpad Mode
-Touchpad mode uses touch input for relative cursor control instead of mapping touches to absolute
-screen positions. A one-finger tap clicks, a double-tap followed by movement drags, a two-finger
-gesture scrolls, and two- and three-finger taps produce right and middle clicks. The input settings
-allow these gestures, their sensitivity, tap timing, and movement tolerances to be customized and
-saved on the client device.
+Touchpad mode makes the tablet screen behave like a laptop touchpad. Touch input moves the pointer
+relative to its current position instead of mapping each touch to an absolute screen coordinate.
+This is useful when absolute positioning is inconvenient or behaves unexpectedly in applications
+such as MediBang Paint. Pen and stylus input continue to use their normal behavior.
+
+Available gestures:
+
+- **One-finger drag:** Move the mouse pointer.
+- **One-finger tap:** Perform a left click.
+- **Double-tap and drag:** Hold the left mouse button while moving, for drawing, selecting, or
+  dragging objects.
+- **Two-finger drag:** Scroll vertically or horizontally.
+- **Two-finger tap:** Perform a right click.
+- **Three-finger tap:** Perform a middle click.
+- **Gesture cancellation or disconnection:** Safely release any mouse buttons held by touchpad
+  mode.
+
+The following options can be customized independently:
+
+- Cursor and scrolling sensitivity
+- Maximum tap duration
+- Maximum interval and distance between double taps
+- Movement tolerance used to distinguish a tap from a drag
+- Tap-to-click, double-tap-and-drag, and two-finger scrolling
+- Reverse scrolling
+- Two-finger right-click and three-finger middle-click
+
+Touchpad preferences are saved locally in the client browser. The settings panel also provides a
+button to restore all touchpad options to their defaults.
 
 ### Keyboard Input
 Weylus supports keyboard input for physical keyboards, so if you have a Bluetooth keyboard, just

--- a/Readme.md
+++ b/Readme.md
@@ -13,6 +13,7 @@ Weylus in action with [Xournal++](https://github.com/xournalpp/xournalpp):
     * [Packages](#packages)
 * [Running](#running)
     * [Fullscreen](#fullscreen)
+    * [Touchpad Mode](#touchpad-mode)
     * [Keyboard Input](#keyboard-input)
     * [Automation](#automation)
     * [Linux](#linux)
@@ -80,6 +81,13 @@ Please only run Weylus in networks you trust as there is no encryption to enable
 You may want to add a bookmark to your home screen on your tablet as this enables running Weylus in
 full screen mode (on iOS/iPadOS this needs to be done with Safari). If you are not on iOS/iPadOS
 there is a button to toggle full screen mode.
+
+### Touchpad Mode
+Touchpad mode uses touch input for relative cursor control instead of mapping touches to absolute
+screen positions. A one-finger tap clicks, a double-tap followed by movement drags, a two-finger
+gesture scrolls, and two- and three-finger taps produce right and middle clicks. The input settings
+allow these gestures, their sensitivity, tap timing, and movement tolerances to be customized and
+saved on the client device.
 
 ### Keyboard Input
 Weylus supports keyboard input for physical keyboards, so if you have a Bluetooth keyboard, just

--- a/lib/linux/uinput.c
+++ b/lib/linux/uinput.c
@@ -106,6 +106,10 @@ void init_mouse(int fd, const char* name, Error* err)
 	// enable scrolling
 	if (ioctl(fd, UI_SET_EVBIT, EV_REL) < 0)
 		ERROR(err, 1, "error: ioctl UI_SET_EVBIT EV_REL");
+	if (ioctl(fd, UI_SET_RELBIT, REL_X) < 0)
+		ERROR(err, 1, "error: ioctl UI_SET_RELBIT REL_X");
+	if (ioctl(fd, UI_SET_RELBIT, REL_Y) < 0)
+		ERROR(err, 1, "error: ioctl UI_SET_RELBIT REL_Y");
 	if (ioctl(fd, UI_SET_RELBIT, REL_WHEEL) < 0)
 		ERROR(err, 1, "error: ioctl UI_SET_RELBIT REL_WHEEL");
 	if (ioctl(fd, UI_SET_RELBIT, REL_HWHEEL) < 0)

--- a/src/input/autopilot_device.rs
+++ b/src/input/autopilot_device.rs
@@ -6,17 +6,29 @@ use autopilot::screen::size as screen_size;
 use tracing::warn;
 
 use crate::input::device::{InputDevice, InputDeviceType};
-use crate::protocol::{Button, KeyboardEvent, KeyboardEventType, PointerEvent, WheelEvent};
+use crate::protocol::{
+    Button, KeyboardEvent, KeyboardEventType, PointerEvent, RelativePointerEvent, WheelEvent,
+};
 
 use crate::capturable::{Capturable, Geometry};
 
 pub struct AutoPilotDevice {
     capturable: Box<dyn Capturable>,
+    pressed_buttons: Button,
 }
 
 impl AutoPilotDevice {
     pub fn new(capturable: Box<dyn Capturable>) -> Self {
-        Self { capturable }
+        Self {
+            capturable,
+            pressed_buttons: Button::NONE,
+        }
+    }
+}
+
+impl Drop for AutoPilotDevice {
+    fn drop(&mut self) {
+        <Self as InputDevice>::release_buttons(self);
     }
 }
 
@@ -27,6 +39,10 @@ impl InputDevice for AutoPilotDevice {
             i32::MIN..=-1 => mouse::scroll(ScrollDirection::Down, 1),
             0 => {}
         }
+    }
+
+    fn send_touchpad_wheel_event(&mut self, event: &WheelEvent) {
+        self.send_wheel_event(event);
     }
 
     fn send_pointer_event(&mut self, event: &PointerEvent) {
@@ -73,6 +89,67 @@ impl InputDevice for AutoPilotDevice {
             }
             _ => (),
         }
+        if event
+            .button
+            .intersects(Button::PRIMARY | Button::SECONDARY | Button::AUXILARY)
+        {
+            if event.buttons.contains(event.button) {
+                self.pressed_buttons.insert(event.button);
+            } else {
+                self.pressed_buttons.remove(event.button);
+            }
+        }
+    }
+
+    fn send_relative_pointer_event(&mut self, event: &RelativePointerEvent) {
+        if let Err(err) = self.capturable.before_input() {
+            warn!("Failed to activate window, sending no input ({})", err);
+            return;
+        }
+        match event.button {
+            Button::PRIMARY => {
+                mouse::toggle(mouse::Button::Left, event.buttons.contains(event.button))
+            }
+            Button::AUXILARY => {
+                mouse::toggle(mouse::Button::Middle, event.buttons.contains(event.button))
+            }
+            Button::SECONDARY => {
+                mouse::toggle(mouse::Button::Right, event.buttons.contains(event.button))
+            }
+            _ => (),
+        }
+        if event.dx != 0 || event.dy != 0 {
+            let location = mouse::location();
+            if let Err(err) = mouse::move_to(autopilot::geometry::Point::new(
+                location.x + event.dx as f64,
+                location.y + event.dy as f64,
+            )) {
+                warn!("Could not move mouse: {}", err);
+            }
+        }
+        if event
+            .button
+            .intersects(Button::PRIMARY | Button::SECONDARY | Button::AUXILARY)
+        {
+            if event.buttons.contains(event.button) {
+                self.pressed_buttons.insert(event.button);
+            } else {
+                self.pressed_buttons.remove(event.button);
+            }
+        }
+    }
+
+    fn release_buttons(&mut self) {
+        if self.pressed_buttons.contains(Button::PRIMARY) {
+            mouse::toggle(mouse::Button::Left, false);
+        }
+        if self.pressed_buttons.contains(Button::SECONDARY) {
+            mouse::toggle(mouse::Button::Right, false);
+        }
+        if self.pressed_buttons.contains(Button::AUXILARY) {
+            mouse::toggle(mouse::Button::Middle, false);
+        }
+        self.pressed_buttons = Button::NONE;
     }
 
     fn send_keyboard_event(&mut self, event: &KeyboardEvent) {

--- a/src/input/autopilot_device_win.rs
+++ b/src/input/autopilot_device_win.rs
@@ -7,7 +7,8 @@ use tracing::warn;
 use crate::input::autopilot_device::AutoPilotDevice;
 use crate::input::device::{InputDevice, InputDeviceType};
 use crate::protocol::{
-    Button, KeyboardEvent, PointerEvent, PointerEventType, PointerType, WheelEvent,
+    Button, KeyboardEvent, PointerEvent, PointerEventType, PointerType, RelativePointerEvent,
+    WheelEvent,
 };
 
 use crate::capturable::{Capturable, Geometry};
@@ -18,6 +19,7 @@ pub struct WindowsInput {
     pointer_device_handle: *mut HSYNTHETICPOINTERDEVICE__,
     touch_device_handle: *mut HSYNTHETICPOINTERDEVICE__,
     multitouch_map: std::collections::HashMap<i64, POINTER_TYPE_INFO>,
+    pressed_buttons: Button,
 }
 
 impl WindowsInput {
@@ -30,14 +32,46 @@ impl WindowsInput {
                 pointer_device_handle: CreateSyntheticPointerDevice(PT_PEN, 1, 1),
                 touch_device_handle: CreateSyntheticPointerDevice(PT_TOUCH, 5, 1),
                 multitouch_map: std::collections::HashMap::new(),
+                pressed_buttons: Button::NONE,
             }
         }
+    }
+}
+
+impl Drop for WindowsInput {
+    fn drop(&mut self) {
+        <Self as InputDevice>::release_buttons(self);
     }
 }
 
 impl InputDevice for WindowsInput {
     fn send_wheel_event(&mut self, event: &WheelEvent) {
         unsafe { mouse_event(MOUSEEVENTF_WHEEL, 0, 0, event.dy as DWORD, 0) };
+    }
+
+    fn send_touchpad_wheel_event(&mut self, event: &WheelEvent) {
+        if event.dy != 0 {
+            unsafe {
+                mouse_event(
+                    MOUSEEVENTF_WHEEL,
+                    0,
+                    0,
+                    (event.dy.signum() * i32::from(WHEEL_DELTA)) as DWORD,
+                    0,
+                )
+            };
+        }
+        if event.dx != 0 {
+            unsafe {
+                mouse_event(
+                    MOUSEEVENTF_HWHEEL,
+                    0,
+                    0,
+                    (event.dx.signum() * i32::from(WHEEL_DELTA)) as DWORD,
+                    0,
+                )
+            };
+        }
     }
 
     fn send_pointer_event(&mut self, event: &PointerEvent) {
@@ -211,6 +245,60 @@ impl InputDevice for WindowsInput {
             }
             PointerType::Unknown => todo!(),
         }
+    }
+
+    fn send_relative_pointer_event(&mut self, event: &RelativePointerEvent) {
+        if let Err(err) = self.capturable.before_input() {
+            warn!("Failed to activate window, sending no input ({})", err);
+            return;
+        }
+
+        let mut flags = 0;
+        if event.dx != 0 || event.dy != 0 {
+            flags |= MOUSEEVENTF_MOVE;
+        }
+        flags |= match (event.button, event.buttons.contains(event.button)) {
+            (Button::PRIMARY, true) => MOUSEEVENTF_LEFTDOWN,
+            (Button::PRIMARY, false) => MOUSEEVENTF_LEFTUP,
+            (Button::SECONDARY, true) => MOUSEEVENTF_RIGHTDOWN,
+            (Button::SECONDARY, false) => MOUSEEVENTF_RIGHTUP,
+            (Button::AUXILARY, true) => MOUSEEVENTF_MIDDLEDOWN,
+            (Button::AUXILARY, false) => MOUSEEVENTF_MIDDLEUP,
+            _ => 0,
+        };
+        if flags != 0 {
+            // Keep the initial drag movement and button-down in one native event.
+            // Drawing applications may otherwise see the move before the button.
+            unsafe { mouse_event(flags, event.dx as DWORD, event.dy as DWORD, 0, 0) };
+        }
+
+        if event
+            .button
+            .intersects(Button::PRIMARY | Button::SECONDARY | Button::AUXILARY)
+        {
+            if event.buttons.contains(event.button) {
+                self.pressed_buttons.insert(event.button);
+            } else {
+                self.pressed_buttons.remove(event.button);
+            }
+        }
+    }
+
+    fn release_buttons(&mut self) {
+        let mut flags = 0;
+        if self.pressed_buttons.contains(Button::PRIMARY) {
+            flags |= MOUSEEVENTF_LEFTUP;
+        }
+        if self.pressed_buttons.contains(Button::SECONDARY) {
+            flags |= MOUSEEVENTF_RIGHTUP;
+        }
+        if self.pressed_buttons.contains(Button::AUXILARY) {
+            flags |= MOUSEEVENTF_MIDDLEUP;
+        }
+        if flags != 0 {
+            unsafe { mouse_event(flags, 0, 0, 0, 0) };
+        }
+        self.pressed_buttons = Button::NONE;
     }
 
     fn send_keyboard_event(&mut self, event: &KeyboardEvent) {

--- a/src/input/device.rs
+++ b/src/input/device.rs
@@ -1,5 +1,5 @@
 use crate::capturable::Capturable;
-use crate::protocol::{KeyboardEvent, PointerEvent, WheelEvent};
+use crate::protocol::{KeyboardEvent, PointerEvent, RelativePointerEvent, WheelEvent};
 
 #[derive(PartialEq, Eq)]
 pub enum InputDeviceType {
@@ -11,7 +11,10 @@ pub enum InputDeviceType {
 
 pub trait InputDevice {
     fn send_wheel_event(&mut self, event: &WheelEvent);
+    fn send_touchpad_wheel_event(&mut self, event: &WheelEvent);
     fn send_pointer_event(&mut self, event: &PointerEvent);
+    fn send_relative_pointer_event(&mut self, event: &RelativePointerEvent);
+    fn release_buttons(&mut self);
     fn send_keyboard_event(&mut self, event: &KeyboardEvent);
     fn set_capturable(&mut self, capturable: Box<dyn Capturable>);
     fn device_type(&self) -> InputDeviceType;

--- a/src/input/uinput_device.rs
+++ b/src/input/uinput_device.rs
@@ -8,7 +8,7 @@ use crate::capturable::{Capturable, Geometry};
 use crate::input::device::{InputDevice, InputDeviceType};
 use crate::protocol::{
     Button, KeyboardEvent, KeyboardEventType, KeyboardLocation, PointerEvent, PointerEventType,
-    PointerType, Rect, WheelEvent,
+    PointerType, Rect, RelativePointerEvent, WheelEvent,
 };
 
 use crate::cerror::CError;
@@ -46,6 +46,7 @@ pub struct UInputDevice {
     num_stylus_mapping_tries: usize,
     num_touch_mapping_tries: usize,
     x11ctx: Option<X11Context>,
+    pressed_buttons: Button,
 }
 
 impl UInputDevice {
@@ -111,6 +112,7 @@ impl UInputDevice {
             num_stylus_mapping_tries: 0,
             num_touch_mapping_tries: 0,
             x11ctx: X11Context::new(),
+            pressed_buttons: Button::NONE,
         })
     }
 
@@ -161,6 +163,7 @@ impl UInputDevice {
 
 impl Drop for UInputDevice {
     fn drop(&mut self) {
+        <Self as InputDevice>::release_buttons(self);
         unsafe {
             destroy_uinput_device(self.keyboard_fd);
             destroy_uinput_device(self.stylus_fd);
@@ -191,8 +194,8 @@ const EC_KEY_TOOL_DOUBLETAP: c_int = 0x14d;
 const EC_KEY_TOOL_TRIPLETAP: c_int = 0x14e;
 const EC_KEY_TOOL_QUADTAP: c_int = 0x14f; /* Four fingers on trackpad */
 const EC_KEY_TOOL_QUINTTAP: c_int = 0x148; /* Five fingers on trackpad */
-//const EC_RELATIVE_X: c_int = 0x00;
-//const EC_RELATIVE_Y: c_int = 0x01;
+const EC_RELATIVE_X: c_int = 0x00;
+const EC_RELATIVE_Y: c_int = 0x01;
 
 const EC_REL_HWHEEL: c_int = 0x06;
 const EC_REL_WHEEL: c_int = 0x08;
@@ -273,6 +276,10 @@ impl InputDevice for UInputDevice {
             (event.timestamp % (i32::MAX as u64 + 1)) as i32,
         );
         self.send(self.mouse_fd, ET_SYNC, EC_SYNC_REPORT, 0);
+    }
+
+    fn send_touchpad_wheel_event(&mut self, event: &WheelEvent) {
+        self.send_wheel_event(event);
     }
 
     fn send_pointer_event(&mut self, event: &PointerEvent) {
@@ -638,6 +645,67 @@ impl InputDevice for UInputDevice {
                 self.send(self.mouse_fd, ET_SYNC, EC_SYNC_REPORT, 0);
             }
         }
+    }
+
+    fn send_relative_pointer_event(&mut self, event: &RelativePointerEvent) {
+        if let Err(err) = self.capturable.before_input() {
+            warn!("Failed to activate window, sending no input ({})", err);
+            return;
+        }
+        match event.button {
+            Button::PRIMARY => self.send(
+                self.mouse_fd,
+                ET_KEY,
+                EC_KEY_MOUSE_LEFT,
+                i32::from(event.buttons.contains(event.button)),
+            ),
+            Button::SECONDARY => self.send(
+                self.mouse_fd,
+                ET_KEY,
+                EC_KEY_MOUSE_RIGHT,
+                i32::from(event.buttons.contains(event.button)),
+            ),
+            Button::AUXILARY => self.send(
+                self.mouse_fd,
+                ET_KEY,
+                EC_KEY_MOUSE_MIDDLE,
+                i32::from(event.buttons.contains(event.button)),
+            ),
+            _ => (),
+        }
+        if event.dx != 0 {
+            self.send(self.mouse_fd, ET_RELATIVE, EC_RELATIVE_X, event.dx);
+        }
+        if event.dy != 0 {
+            self.send(self.mouse_fd, ET_RELATIVE, EC_RELATIVE_Y, event.dy);
+        }
+        if event
+            .button
+            .intersects(Button::PRIMARY | Button::SECONDARY | Button::AUXILARY)
+        {
+            if event.buttons.contains(event.button) {
+                self.pressed_buttons.insert(event.button);
+            } else {
+                self.pressed_buttons.remove(event.button);
+            }
+        }
+        self.send(self.mouse_fd, ET_SYNC, EC_SYNC_REPORT, 0);
+    }
+
+    fn release_buttons(&mut self) {
+        if self.pressed_buttons.contains(Button::PRIMARY) {
+            self.send(self.mouse_fd, ET_KEY, EC_KEY_MOUSE_LEFT, 0);
+        }
+        if self.pressed_buttons.contains(Button::SECONDARY) {
+            self.send(self.mouse_fd, ET_KEY, EC_KEY_MOUSE_RIGHT, 0);
+        }
+        if self.pressed_buttons.contains(Button::AUXILARY) {
+            self.send(self.mouse_fd, ET_KEY, EC_KEY_MOUSE_MIDDLE, 0);
+        }
+        if !self.pressed_buttons.is_empty() {
+            self.send(self.mouse_fd, ET_SYNC, EC_SYNC_REPORT, 0);
+        }
+        self.pressed_buttons = Button::NONE;
     }
 
     fn send_keyboard_event(&mut self, event: &KeyboardEvent) {

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -15,7 +15,10 @@ pub struct ClientConfiguration {
 #[derive(Serialize, Deserialize, Debug)]
 pub enum MessageInbound {
     PointerEvent(PointerEvent),
+    RelativePointerEvent(RelativePointerEvent),
+    ReleaseButtons,
     WheelEvent(WheelEvent),
+    TouchpadWheelEvent(WheelEvent),
     KeyboardEvent(KeyboardEvent),
     GetCapturableList,
     Config(ClientConfiguration),
@@ -179,6 +182,16 @@ pub struct PointerEvent {
     pub twist: i32,
     pub width: f64,
     pub height: f64,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct RelativePointerEvent {
+    pub dx: i32,
+    pub dy: i32,
+    #[serde(deserialize_with = "button_from")]
+    pub button: Button,
+    #[serde(deserialize_with = "button_from")]
+    pub buttons: Button,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -13,7 +13,7 @@ use crate::capturable::{get_capturables, Capturable, Recorder};
 use crate::input::device::{InputDevice, InputDeviceType};
 use crate::protocol::{
     ClientConfiguration, KeyboardEvent, MessageInbound, MessageOutbound, PointerEvent,
-    WeylusReceiver, WeylusSender, WheelEvent,
+    RelativePointerEvent, WeylusReceiver, WeylusSender, WheelEvent,
 };
 
 use crate::cerror::CErrorCode;
@@ -111,7 +111,14 @@ impl<S, R, FnUInput> WeylusClientHandler<S, R, FnUInput> {
                     trace!("Received message: {message:?}");
                     match message {
                         MessageInbound::PointerEvent(event) => self.process_pointer_event(&event),
+                        MessageInbound::RelativePointerEvent(event) => {
+                            self.process_relative_pointer_event(&event)
+                        }
+                        MessageInbound::ReleaseButtons => self.release_buttons(),
                         MessageInbound::WheelEvent(event) => self.process_wheel_event(&event),
+                        MessageInbound::TouchpadWheelEvent(event) => {
+                            self.process_touchpad_wheel_event(&event)
+                        }
                         MessageInbound::KeyboardEvent(event) => self.process_keyboard_event(&event),
                         MessageInbound::GetCapturableList => self.send_capturable_list(),
                         MessageInbound::Config(config) => self.update_config(config),
@@ -168,6 +175,13 @@ impl<S, R, FnUInput> WeylusClientHandler<S, R, FnUInput> {
         }
     }
 
+    fn process_touchpad_wheel_event(&mut self, event: &WheelEvent) {
+        match &mut self.input_device {
+            Some(i) => i.send_touchpad_wheel_event(event),
+            None => warn!("Input device is not initalized, can not process TouchpadWheelEvent!"),
+        }
+    }
+
     fn process_pointer_event(&mut self, event: &PointerEvent) {
         if self.input_device.is_some() {
             self.input_device
@@ -176,6 +190,19 @@ impl<S, R, FnUInput> WeylusClientHandler<S, R, FnUInput> {
                 .send_pointer_event(event)
         } else {
             warn!("Input device is not initalized, can not process PointerEvent!");
+        }
+    }
+
+    fn process_relative_pointer_event(&mut self, event: &RelativePointerEvent) {
+        match &mut self.input_device {
+            Some(i) => i.send_relative_pointer_event(event),
+            None => warn!("Input device is not initalized, can not process RelativePointerEvent!"),
+        }
+    }
+
+    fn release_buttons(&mut self) {
+        if let Some(input_device) = self.input_device.as_mut() {
+            input_device.release_buttons();
         }
     }
 

--- a/ts/lib.ts
+++ b/ts/lib.ts
@@ -116,6 +116,14 @@ class Settings {
     scale_video_input: HTMLInputElement;
     scale_video_output: HTMLOutputElement;
     range_min_pressure: HTMLInputElement;
+    touchpad_sensitivity_input: HTMLInputElement;
+    touchpad_sensitivity_output: HTMLOutputElement;
+    touchpad_scroll_sensitivity_input: HTMLInputElement;
+    touchpad_tap_duration_input: HTMLInputElement;
+    touchpad_double_tap_interval_input: HTMLInputElement;
+    touchpad_movement_tolerance_input: HTMLInputElement;
+    touchpad_double_tap_distance_input: HTMLInputElement;
+    touchpad_options: HTMLFieldSetElement;
     check_aggressive_seek: HTMLInputElement;
     client_name_input: HTMLInputElement;
     visible: boolean;
@@ -133,6 +141,14 @@ class Settings {
         this.scale_video_input = document.getElementById("scale_video") as HTMLInputElement;
         this.scale_video_output = this.scale_video_input.nextElementSibling as HTMLOutputElement;
         this.range_min_pressure = document.getElementById("min_pressure") as HTMLInputElement;
+        this.touchpad_sensitivity_input = document.getElementById("touchpad_sensitivity") as HTMLInputElement;
+        this.touchpad_sensitivity_output = this.touchpad_sensitivity_input.nextElementSibling as HTMLOutputElement;
+        this.touchpad_scroll_sensitivity_input = document.getElementById("touchpad_scroll_sensitivity") as HTMLInputElement;
+        this.touchpad_tap_duration_input = document.getElementById("touchpad_tap_duration") as HTMLInputElement;
+        this.touchpad_double_tap_interval_input = document.getElementById("touchpad_double_tap_interval") as HTMLInputElement;
+        this.touchpad_movement_tolerance_input = document.getElementById("touchpad_movement_tolerance") as HTMLInputElement;
+        this.touchpad_double_tap_distance_input = document.getElementById("touchpad_double_tap_distance") as HTMLInputElement;
+        this.touchpad_options = document.getElementById("touchpad_options") as HTMLFieldSetElement;
         this.client_name_input = document.getElementById("client_name") as HTMLInputElement;
         this.frame_rate_input.oninput = () => {
             this.frame_rate_output.value = Math.round(frame_rate_scale(this.frame_rate_input.valueAsNumber)).toString();
@@ -141,6 +157,19 @@ class Settings {
             let [w, h] = calc_max_video_resolution(this.scale_video_input.valueAsNumber)
             this.scale_video_output.value = w + "x" + h
         }
+        this.touchpad_sensitivity_input.oninput = () => {
+            this.touchpad_sensitivity_output.value = this.touchpad_sensitivity_input.valueAsNumber.toFixed(2) + "x";
+        }
+        let bind_touchpad_range = (input: HTMLInputElement, format: (value: number) => string) => {
+            let output = input.nextElementSibling as HTMLOutputElement;
+            input.oninput = () => output.value = format(input.valueAsNumber);
+            input.onchange = () => this.save_settings();
+        };
+        bind_touchpad_range(this.touchpad_scroll_sensitivity_input, (value) => value.toFixed(2) + "x");
+        bind_touchpad_range(this.touchpad_tap_duration_input, (value) => value.toFixed(0) + " ms");
+        bind_touchpad_range(this.touchpad_double_tap_interval_input, (value) => value.toFixed(0) + " ms");
+        bind_touchpad_range(this.touchpad_movement_tolerance_input, (value) => value.toFixed(0) + " px");
+        bind_touchpad_range(this.touchpad_double_tap_distance_input, (value) => value.toFixed(0) + " px");
         this.visible = true;
 
         // Settings UI
@@ -210,6 +239,21 @@ class Settings {
         this.checks.get("enable_mouse").onchange = upd_pointer;
         this.checks.get("enable_stylus").onchange = upd_pointer;
         this.checks.get("enable_touch").onchange = upd_pointer;
+        this.checks.get("touchpad_mode").onchange = () => {
+            this.update_touchpad_options();
+            upd_pointer();
+        };
+        for (const key of [
+            "touchpad_tap_to_click",
+            "touchpad_double_tap_drag",
+            "touchpad_two_finger_scroll",
+            "touchpad_reverse_scroll",
+            "touchpad_two_finger_tap",
+            "touchpad_three_finger_tap"])
+            this.checks.get(key).onchange = upd_pointer;
+        this.touchpad_sensitivity_input.onchange = () => this.save_settings();
+        document.getElementById("reset_touchpad").onclick = () => this.reset_touchpad_defaults();
+        this.update_touchpad_options();
 
         this.checks.get("energysaving").onchange = (e) => {
             this.save_settings();
@@ -261,6 +305,12 @@ class Settings {
         settings["frame_rate"] = frame_rate_scale(this.frame_rate_input.valueAsNumber).toString();
         settings["scale_video"] = this.scale_video_input.value;
         settings["min_pressure"] = this.range_min_pressure.value;
+        settings["touchpad_sensitivity"] = this.touchpad_sensitivity_input.value;
+        settings["touchpad_scroll_sensitivity"] = this.touchpad_scroll_sensitivity_input.value;
+        settings["touchpad_tap_duration"] = this.touchpad_tap_duration_input.value;
+        settings["touchpad_double_tap_interval"] = this.touchpad_double_tap_interval_input.value;
+        settings["touchpad_movement_tolerance"] = this.touchpad_movement_tolerance_input.value;
+        settings["touchpad_double_tap_distance"] = this.touchpad_double_tap_distance_input.value;
         settings["custom_input_areas"] = this.custom_input_areas;
         settings["client_name"] = this.client_name_input.value;
         localStorage.setItem("settings", JSON.stringify(settings));
@@ -297,6 +347,16 @@ class Settings {
             let min_pressure = settings["min_pressure"];
             if (min_pressure)
                 this.range_min_pressure.value = min_pressure;
+
+            let touchpad_sensitivity = Number(settings["touchpad_sensitivity"]);
+            if (touchpad_sensitivity >= 0.25 && touchpad_sensitivity <= 3)
+                this.touchpad_sensitivity_input.value = touchpad_sensitivity.toString();
+            this.touchpad_sensitivity_output.value = this.touchpad_sensitivity_input.valueAsNumber.toFixed(2) + "x";
+            this.load_range_setting(settings, "touchpad_scroll_sensitivity", this.touchpad_scroll_sensitivity_input, (value) => value.toFixed(2) + "x");
+            this.load_range_setting(settings, "touchpad_tap_duration", this.touchpad_tap_duration_input, (value) => value.toFixed(0) + " ms");
+            this.load_range_setting(settings, "touchpad_double_tap_interval", this.touchpad_double_tap_interval_input, (value) => value.toFixed(0) + " ms");
+            this.load_range_setting(settings, "touchpad_movement_tolerance", this.touchpad_movement_tolerance_input, (value) => value.toFixed(0) + " px");
+            this.load_range_setting(settings, "touchpad_double_tap_distance", this.touchpad_double_tap_distance_input, (value) => value.toFixed(0) + " px");
 
             this.custom_input_areas = settings["custom_input_areas"];
 
@@ -348,6 +408,74 @@ class Settings {
         if (this.checks.get("enable_touch").checked)
             ptrs.push("touch");
         return ptrs;
+    }
+
+    touchpad_sensitivity() {
+        return this.touchpad_sensitivity_input.valueAsNumber;
+    }
+
+    touchpad_scroll_sensitivity() {
+        return this.touchpad_scroll_sensitivity_input.valueAsNumber;
+    }
+
+    touchpad_tap_duration() {
+        return this.touchpad_tap_duration_input.valueAsNumber;
+    }
+
+    touchpad_double_tap_interval() {
+        return this.touchpad_double_tap_interval_input.valueAsNumber;
+    }
+
+    touchpad_movement_tolerance() {
+        return this.touchpad_movement_tolerance_input.valueAsNumber;
+    }
+
+    touchpad_double_tap_distance() {
+        return this.touchpad_double_tap_distance_input.valueAsNumber;
+    }
+
+    load_range_setting(saved: any, key: string, input: HTMLInputElement, format: (value: number) => string) {
+        let value = Number(saved[key]);
+        let min = Number(input.min);
+        let max = Number(input.max);
+        if (Number.isFinite(value) && value >= min && value <= max)
+            input.value = value.toString();
+        (input.nextElementSibling as HTMLOutputElement).value = format(input.valueAsNumber);
+    }
+
+    update_touchpad_options() {
+        let enabled = this.checks.get("touchpad_mode").checked;
+        this.touchpad_options.classList.toggle("touchpad_disabled", !enabled);
+        this.touchpad_options.querySelectorAll("input, button").forEach((element) => {
+            if ((element as HTMLElement).id != "touchpad_mode")
+                (element as HTMLInputElement | HTMLButtonElement).disabled = !enabled;
+        });
+    }
+
+    reset_touchpad_defaults() {
+        let defaults = {
+            "touchpad_sensitivity": "1",
+            "touchpad_scroll_sensitivity": "1",
+            "touchpad_tap_duration": "200",
+            "touchpad_double_tap_interval": "300",
+            "touchpad_movement_tolerance": "8",
+            "touchpad_double_tap_distance": "25",
+        };
+        for (const key of Object.keys(defaults)) {
+            let input = document.getElementById(key) as HTMLInputElement;
+            input.value = defaults[key];
+            input.dispatchEvent(new Event("input"));
+        }
+        for (const key of [
+            "touchpad_tap_to_click",
+            "touchpad_double_tap_drag",
+            "touchpad_two_finger_scroll",
+            "touchpad_two_finger_tap",
+            "touchpad_three_finger_tap"])
+            this.checks.get(key).checked = true;
+        this.checks.get("touchpad_reverse_scroll").checked = false;
+        this.save_settings();
+        new PointerHandler(this.webSocket);
     }
 
     toggle() {
@@ -686,15 +814,54 @@ class Painter {
     }
 }
 
+interface TouchContact {
+    x: number;
+    y: number;
+    startX: number;
+    startY: number;
+    maxMovement: number;
+}
+
+let active_pointer_handler: PointerHandler = null;
+
 class PointerHandler {
     webSocket: WebSocket;
     pointerTypes: string[];
+    touches: Map<number, TouchContact>;
+    touchGestureStarted: number;
+    gestureFingerCount: number;
+    gestureMoved: boolean;
+    dragCandidate: boolean;
+    dragging: boolean;
+    lastTapTime: number;
+    lastTapX: number;
+    lastTapY: number;
+    relativeRemainderX: number;
+    relativeRemainderY: number;
+    scrollRemainderX: number;
+    scrollRemainderY: number;
 
     constructor(webSocket: WebSocket) {
+        if (active_pointer_handler)
+            active_pointer_handler.cleanup();
+        active_pointer_handler = this;
         let video = document.getElementById("video");
         let canvas = document.getElementById("canvas");
         this.webSocket = webSocket;
         this.pointerTypes = settings.pointer_types();
+        this.touches = new Map();
+        this.touchGestureStarted = 0;
+        this.gestureFingerCount = 0;
+        this.gestureMoved = false;
+        this.dragCandidate = false;
+        this.dragging = false;
+        this.lastTapTime = 0;
+        this.lastTapX = 0;
+        this.lastTapY = 0;
+        this.relativeRemainderX = 0;
+        this.relativeRemainderY = 0;
+        this.scrollRemainderX = 0;
+        this.scrollRemainderY = 0;
 
         video.onpointerdown = (e) => this.onEvent(e, "pointerdown");
         video.onpointerup = (e) => this.onEvent(e, "pointerup");
@@ -710,14 +877,14 @@ class PointerHandler {
             painter = new Painter(canvas as HTMLCanvasElement);
 
         if (painter && painter.initialized) {
-            canvas.onpointerdown = (e) => { this.onEvent(e, "pointerdown"); painter.onstart(e); };
-            canvas.onpointerup = (e) => { this.onEvent(e, "pointerup"); painter.onstop(e); };
-            canvas.onpointercancel = (e) => { this.onEvent(e, "pointercancel"); painter.onstop(e); };
-            canvas.onpointermove = (e) => { this.onEvent(e, "pointermove"); painter.onmove(e); };
-            canvas.onpointerout = (e) => { this.onEvent(e, "pointerout"); painter.onstop(e); };
-            canvas.onpointerleave = (e) => { this.onEvent(e, "pointerleave"); painter.onstop(e); };
-            canvas.onpointerenter = (e) => { this.onEvent(e, "pointerenter"); painter.onmove(e); };
-            canvas.onpointerover = (e) => { this.onEvent(e, "pointerover"); painter.onmove(e); };
+            canvas.onpointerdown = (e) => { if (this.onEvent(e, "pointerdown")) painter.onstart(e); };
+            canvas.onpointerup = (e) => { if (this.onEvent(e, "pointerup")) painter.onstop(e); };
+            canvas.onpointercancel = (e) => { if (this.onEvent(e, "pointercancel")) painter.onstop(e); };
+            canvas.onpointermove = (e) => { if (this.onEvent(e, "pointermove")) painter.onmove(e); };
+            canvas.onpointerout = (e) => { if (this.onEvent(e, "pointerout")) painter.onstop(e); };
+            canvas.onpointerleave = (e) => { if (this.onEvent(e, "pointerleave")) painter.onstop(e); };
+            canvas.onpointerenter = (e) => { if (this.onEvent(e, "pointerenter")) painter.onmove(e); };
+            canvas.onpointerover = (e) => { if (this.onEvent(e, "pointerover")) painter.onmove(e); };
         } else {
             canvas.onpointerdown = (e) => this.onEvent(e, "pointerdown");
             canvas.onpointerup = (e) => this.onEvent(e, "pointerup");
@@ -738,6 +905,187 @@ class PointerHandler {
         for (let elem of [video, canvas]) {
             elem.onwheel = (e) => {
                 this.webSocket.send(JSON.stringify({ "WheelEvent": new WEvent(e) }));
+            }
+        }
+    }
+
+    send(message: object | string) {
+        if (this.webSocket.readyState === WebSocket.OPEN)
+            this.webSocket.send(JSON.stringify(message));
+    }
+
+    sendRelative(dx: number, dy: number, button: number = 0, buttons: number = 0) {
+        this.relativeRemainderX += dx;
+        this.relativeRemainderY += dy;
+        let moveX = Math.trunc(this.relativeRemainderX);
+        let moveY = Math.trunc(this.relativeRemainderY);
+        this.relativeRemainderX -= moveX;
+        this.relativeRemainderY -= moveY;
+        if (moveX || moveY || button)
+            this.send({ "RelativePointerEvent": { "dx": moveX, "dy": moveY, "button": button, "buttons": buttons } });
+    }
+
+    sendButton(button: number, down: boolean) {
+        this.sendRelative(0, 0, button, down ? button : 0);
+    }
+
+    click(button: number) {
+        this.sendButton(button, true);
+        this.sendButton(button, false);
+    }
+
+    releaseButtons() {
+        this.send("ReleaseButtons");
+        this.dragCandidate = false;
+        this.dragging = false;
+    }
+
+    cleanup() {
+        this.releaseButtons();
+        this.touches.clear();
+        this.gestureFingerCount = 0;
+        this.gestureMoved = false;
+        this.touchGestureStarted = 0;
+        this.relativeRemainderX = 0;
+        this.relativeRemainderY = 0;
+        this.scrollRemainderX = 0;
+        this.scrollRemainderY = 0;
+    }
+
+    contactMovement(contact: TouchContact) {
+        return Math.hypot(contact.x - contact.startX, contact.y - contact.startY);
+    }
+
+    resetTouchGesture() {
+        this.touches.clear();
+        this.touchGestureStarted = 0;
+        this.gestureFingerCount = 0;
+        this.gestureMoved = false;
+        this.dragCandidate = false;
+        this.relativeRemainderX = 0;
+        this.relativeRemainderY = 0;
+        this.scrollRemainderX = 0;
+        this.scrollRemainderY = 0;
+    }
+
+    handleTouchpadEvent(event: PointerEvent, event_type: string) {
+        event.preventDefault();
+        event.stopPropagation();
+
+        if (event_type == "pointercancel") {
+            this.cleanup();
+            return;
+        }
+
+        if (event_type == "pointerdown") {
+            (event.target as HTMLElement).setPointerCapture(event.pointerId);
+            this.touches.set(event.pointerId, {
+                x: event.clientX,
+                y: event.clientY,
+                startX: event.clientX,
+                startY: event.clientY,
+                maxMovement: 0,
+            });
+
+            if (this.touches.size == 1) {
+                this.touchGestureStarted = performance.now();
+                this.gestureFingerCount = 1;
+                this.gestureMoved = false;
+                let closeToLastTap = Math.hypot(event.clientX - this.lastTapX, event.clientY - this.lastTapY) <
+                    settings.touchpad_double_tap_distance();
+                if (settings.checks.get("touchpad_double_tap_drag").checked &&
+                    this.lastTapTime &&
+                    performance.now() - this.lastTapTime < settings.touchpad_double_tap_interval() &&
+                    closeToLastTap) {
+                    this.dragCandidate = true;
+                    this.lastTapTime = 0;
+                }
+            } else {
+                if (this.dragging)
+                    this.releaseButtons();
+                this.gestureFingerCount = Math.max(this.gestureFingerCount, this.touches.size);
+                this.lastTapTime = 0;
+                this.scrollRemainderX = 0;
+                this.scrollRemainderY = 0;
+            }
+            return;
+        }
+
+        let contact = this.touches.get(event.pointerId);
+        if (!contact)
+            return;
+
+        if (event_type == "pointermove") {
+            let dx = event.clientX - contact.x;
+            let dy = event.clientY - contact.y;
+            contact.x = event.clientX;
+            contact.y = event.clientY;
+            contact.maxMovement = Math.max(contact.maxMovement, this.contactMovement(contact));
+            if (contact.maxMovement >= settings.touchpad_movement_tolerance())
+                this.gestureMoved = true;
+
+            if (this.gestureFingerCount == 2 && this.touches.size == 2 &&
+                settings.checks.get("touchpad_two_finger_scroll").checked) {
+                this.scrollRemainderX += dx / 2;
+                this.scrollRemainderY += dy / 2;
+                const scrollStep = 8 / settings.touchpad_scroll_sensitivity();
+                const scrollDirection = settings.checks.get("touchpad_reverse_scroll").checked ? -1 : 1;
+                while (Math.abs(this.scrollRemainderX) >= scrollStep ||
+                    Math.abs(this.scrollRemainderY) >= scrollStep) {
+                    let wheelX = Math.abs(this.scrollRemainderX) >= scrollStep ?
+                        Math.sign(this.scrollRemainderX) * scrollDirection : 0;
+                    let wheelY = Math.abs(this.scrollRemainderY) >= scrollStep ?
+                        Math.sign(this.scrollRemainderY) * scrollDirection : 0;
+                    this.send({ "TouchpadWheelEvent": { "dx": wheelX, "dy": wheelY, "timestamp": Math.round(event.timeStamp * 1000) } });
+                    this.scrollRemainderX -= wheelX * scrollStep * scrollDirection;
+                    this.scrollRemainderY -= wheelY * scrollStep * scrollDirection;
+                }
+            } else if (this.gestureFingerCount == 1 && this.touches.size == 1) {
+                let sensitivity = settings.touchpad_sensitivity();
+                if (this.dragCandidate && (dx != 0 || dy != 0)) {
+                    this.dragCandidate = false;
+                    this.dragging = true;
+                    this.sendRelative(dx * sensitivity, dy * sensitivity, 1, 1);
+                } else {
+                    this.sendRelative(dx * sensitivity, dy * sensitivity);
+                }
+            }
+            return;
+        }
+
+        if (event_type == "pointerup") {
+            let elapsed = performance.now() - this.touchGestureStarted;
+            contact.x = event.clientX;
+            contact.y = event.clientY;
+            contact.maxMovement = Math.max(contact.maxMovement, this.contactMovement(contact));
+            if (contact.maxMovement >= settings.touchpad_movement_tolerance())
+                this.gestureMoved = true;
+            this.touches.delete(event.pointerId);
+
+            if (this.dragging) {
+                this.releaseButtons();
+                if (this.touches.size == 0)
+                    this.resetTouchGesture();
+                return;
+            }
+
+            if (this.touches.size == 0) {
+                if (elapsed < settings.touchpad_tap_duration() && !this.gestureMoved) {
+                    if (this.gestureFingerCount == 1 &&
+                        settings.checks.get("touchpad_tap_to_click").checked) {
+                        this.click(1);
+                        this.lastTapTime = performance.now();
+                        this.lastTapX = event.clientX;
+                        this.lastTapY = event.clientY;
+                    } else if (this.gestureFingerCount == 2 &&
+                        settings.checks.get("touchpad_two_finger_tap").checked) {
+                        this.click(2);
+                    } else if (this.gestureFingerCount == 3 &&
+                        settings.checks.get("touchpad_three_finger_tap").checked) {
+                        this.click(4);
+                    }
+                }
+                this.resetTouchGesture();
             }
         }
     }
@@ -803,6 +1151,12 @@ class PointerHandler {
             }
         }
         if (this.pointerTypes.includes(event.pointerType)) {
+            if (event.pointerType == "touch" && settings.checks.get("touchpad_mode").checked) {
+                this.handleTouchpadEvent(event, event_type);
+                if (settings.visible)
+                    settings.toggle();
+                return false;
+            }
             let rect = (event.target as HTMLElement).getBoundingClientRect();
             const events = event_type === "pointermove" && typeof event.getCoalescedEvents === 'function' ? event.getCoalescedEvents() : [event];
             for (let event of events) {
@@ -821,7 +1175,9 @@ class PointerHandler {
             if (settings.visible) {
                 settings.toggle();
             }
+            return true;
         }
+        return false;
     }
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,8 @@
     "lib": ["es2020", "dom", "es6"],
     "module": "commonjs",
     "outDir": "www/static",
+    "rootDir": "ts",
+    "strict": false,
     "sourceMap": false
   },
   "include": [

--- a/www/static/style.css
+++ b/www/static/style.css
@@ -131,6 +131,43 @@ input[type='range']::-webkit-slider-runnable-track, input[type="range"]::-moz-ra
     display: block;
     margin-top: 0.5em;
 }
+#touchpad_options {
+    border: 1px solid #7778;
+    border-radius: 0.4em;
+    margin-top: 0.7em;
+    padding: 0.35em 0.6em 0.7em;
+}
+#touchpad_options legend label {
+    margin: 0;
+    font-weight: bold;
+}
+.setting_hint {
+    color: #888;
+    font-size: 0.82em;
+    line-height: 1.25;
+    margin: 0.25em 0 0.65em;
+}
+.touchpad_range {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    column-gap: 0.4em;
+    margin-top: 0.75em;
+}
+.touchpad_range label {
+    grid-column: 1 / -1;
+    margin: 0 0 0.15em !important;
+}
+.touchpad_range input {
+    min-width: 0;
+    width: 100%;
+}
+.touchpad_range output {
+    min-width: 4.5em;
+    text-align: right;
+}
+#touchpad_options.touchpad_disabled > :not(legend):not(.setting_hint) {
+    opacity: 0.45;
+}
 #settings section.hide, section label.hide, section button.hide, #debug_overlay.hide {
     display: none !important;
 }

--- a/www/templates/index.html
+++ b/www/templates/index.html
@@ -51,6 +51,48 @@
                 <label><input type="checkbox" id="enable_mouse" checked /> <span>Enable Mouse</span></label>
                 <label><input type="checkbox" id="enable_stylus" checked /> <span>Enable Stylus</span></label>
                 <label><input type="checkbox" id="enable_touch" checked /> <span>Enable Touch</span></label>
+                <fieldset id="touchpad_options">
+                    <legend><label><input type="checkbox" id="touchpad_mode" /> <span>Touchpad Mode</span></label></legend>
+                    <p class="setting_hint">Use the screen like a laptop touchpad. These controls are saved on this device.</p>
+                    <label><input type="checkbox" id="touchpad_tap_to_click" checked /> <span>Tap to click</span></label>
+                    <label><input type="checkbox" id="touchpad_double_tap_drag" checked /> <span>Double-tap and drag</span></label>
+                    <label><input type="checkbox" id="touchpad_two_finger_scroll" checked /> <span>Two-finger scrolling</span></label>
+                    <label><input type="checkbox" id="touchpad_reverse_scroll" /> <span>Reverse scroll direction</span></label>
+                    <label><input type="checkbox" id="touchpad_two_finger_tap" checked /> <span>Two-finger tap = right click</span></label>
+                    <label><input type="checkbox" id="touchpad_three_finger_tap" checked /> <span>Three-finger tap = middle click</span></label>
+
+                    <div class="touchpad_range">
+                        <label for="touchpad_sensitivity">Cursor sensitivity</label>
+                        <input type="range" id="touchpad_sensitivity" min="0.25" max="3" step="0.05" value="1" />
+                        <output>1.00x</output>
+                    </div>
+                    <div class="touchpad_range">
+                        <label for="touchpad_scroll_sensitivity">Scroll sensitivity</label>
+                        <input type="range" id="touchpad_scroll_sensitivity" min="0.25" max="4" step="0.05" value="1" />
+                        <output>1.00x</output>
+                    </div>
+                    <div class="touchpad_range">
+                        <label for="touchpad_tap_duration">Maximum tap time</label>
+                        <input type="range" id="touchpad_tap_duration" min="80" max="600" step="10" value="200" />
+                        <output>200 ms</output>
+                    </div>
+                    <div class="touchpad_range">
+                        <label for="touchpad_double_tap_interval">Time between double taps</label>
+                        <input type="range" id="touchpad_double_tap_interval" min="100" max="800" step="10" value="300" />
+                        <output>300 ms</output>
+                    </div>
+                    <div class="touchpad_range">
+                        <label for="touchpad_movement_tolerance">Tap movement tolerance</label>
+                        <input type="range" id="touchpad_movement_tolerance" min="2" max="30" step="1" value="8" />
+                        <output>8 px</output>
+                    </div>
+                    <div class="touchpad_range">
+                        <label for="touchpad_double_tap_distance">Double-tap distance</label>
+                        <input type="range" id="touchpad_double_tap_distance" min="5" max="80" step="1" value="25" />
+                        <output>25 px</output>
+                    </div>
+                    <button type="button" id="reset_touchpad">Reset touchpad defaults</button>
+                </fieldset>
                 <label {{#if (not uinput_enabled)}}class="hide" {{/if}}>
                     <input type="checkbox" id="uinput_support" checked />
                     <span>Enable uinput</span>


### PR DESCRIPTION
## Summary
- add relative touchpad cursor control with configurable sensitivity, tap timing, and movement tolerances
- add tap-to-click, double-tap drag, two-finger scrolling, right-click, and middle-click gestures
- persist touchpad preferences on each client device
- support relative input and safe mouse-button cleanup on Windows, Linux uinput, and the generic input backend
- submit the initial Windows drag movement and button-down together for drawing applications such as MediBang Paint

## Testing
- `cargo fmt -- --check`
- `tsc --noEmit`
- `cargo check` on Windows