### PR TITLE
Fix niri/Wayland monitor capture (DMA-BUF) and stylus input mapping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,6 +140,20 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f65693059b6b9c588b9f62fed1cedbf0a8b805631457ea162d68f0de186f3de5"
+dependencies = [
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.115",
+]
 
 [[package]]
 name = "byteorder"
@@ -158,6 +172,32 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "calloop"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
+dependencies = [
+ "bitflags 2.11.0",
+ "log",
+ "polling",
+ "rustix 0.38.44",
+ "slab",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "calloop-wayland-source"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
+dependencies = [
+ "calloop",
+ "rustix 0.38.44",
+ "wayland-backend",
+ "wayland-client",
+]
 
 [[package]]
 name = "captrs"
@@ -285,6 +325,15 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "core-foundation"
@@ -417,6 +466,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cursor-icon"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -544,6 +599,12 @@ dependencies = [
  "quote 1.0.44",
  "syn 2.0.115",
 ]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dxgcap"
@@ -1379,6 +1440,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1410,6 +1483,24 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a5a03cefb0d953ec0be133036f14e109412fa594edc2f77227249db66cc3ed"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "memmap2"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "minipaste"
@@ -1745,6 +1836,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1805,6 +1910,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d68782463e408eb1e668cf6152704bd856c78c5b6417adaee3203d8f4c1fc9ec"
 dependencies = [
  "image 0.25.9",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1925,6 +2039,32 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2071,6 +2211,34 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "smithay-client-toolkit"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytemuck",
+ "calloop",
+ "calloop-wayland-source",
+ "cursor-icon",
+ "libc",
+ "log",
+ "memmap2 0.9.11",
+ "pkg-config",
+ "rustix 0.38.44",
+ "thiserror 1.0.69",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-csd-frame",
+ "wayland-cursor",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+ "wayland-scanner",
+ "xkbcommon",
+ "xkeysym",
+]
 
 [[package]]
 name = "socket2"
@@ -2476,6 +2644,98 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wayland-backend"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "016ccf01d1c58b6f8999612813e17c9b2390f7d70671428869913310f83f54b8"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix 1.1.4",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c36a0f861ad76d0901f2800b46321410d9f73f2ea88aac0650d86c32688073"
+dependencies = [
+ "bitflags 2.11.0",
+ "rustix 1.1.4",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-csd-frame"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
+dependencies = [
+ "bitflags 2.11.0",
+ "cursor-icon",
+ "wayland-backend",
+]
+
+[[package]]
+name = "wayland-cursor"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a52d18780be9b1314328a3de5f930b73d2200112e3849ca6cb11822793fb34d"
+dependencies = [
+ "rustix 1.1.4",
+ "wayland-client",
+ "xcursor",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
+dependencies = [
+ "bitflags 2.11.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.11.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
+dependencies = [
+ "proc-macro2 1.0.106",
+ "quick-xml",
+ "quote 1.0.44",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "weylus"
 version = "0.11.4"
 dependencies = [
@@ -2510,6 +2770,7 @@ dependencies = [
  "serde",
  "serde_json",
  "signal-hook",
+ "smithay-client-toolkit",
  "tokio",
  "toml",
  "tracing",
@@ -2811,6 +3072,32 @@ checksum = "16ccedf556cb1f784d462dd8f24a7804f766d57c0051439d3e4052465263c399"
 dependencies = [
  "libc",
  "x11",
+]
+
+[[package]]
+name = "xcursor"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bec9e4a500ca8864c5b47b8b482a73d62e4237670e5b5f1d6b9e3cae50f28f2b"
+
+[[package]]
+name = "xkbcommon"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13867d259930edc7091a6c41b4ce6eee464328c6ff9659b7e4c668ca20d4c91e"
+dependencies = [
+ "libc",
+ "memmap2 0.8.0",
+ "xkeysym",
+]
+
+[[package]]
+name = "xkeysym"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -971,6 +971,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "gstreamer-allocators"
+version = "0.24.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "995fcebc51d14f09b269a8c0e1875b81196240aad6b56836db1041c3d4094e1e"
+dependencies = [
+ "glib",
+ "gstreamer",
+ "gstreamer-allocators-sys",
+ "libc",
+]
+
+[[package]]
+name = "gstreamer-allocators-sys"
+version = "0.24.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f488cbd148fe6ccddb1095bd9131fb4f6a58419966d33fb40154053eb8d376f4"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "gstreamer-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
 name = "gstreamer-app"
 version = "0.24.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2754,6 +2779,7 @@ dependencies = [
  "fltk",
  "fltk-theme",
  "gstreamer",
+ "gstreamer-allocators",
  "gstreamer-app",
  "gstreamer-video",
  "handlebars",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2788,6 +2788,7 @@ dependencies = [
  "hyper-util",
  "image 0.22.5",
  "image 0.25.9",
+ "libc",
  "num_cpus",
  "percent-encoding",
  "pnet_datalink",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,10 @@ gstreamer-app = { version = "^0.24", features = ["v1_16"] }
 gstreamer-video = "^0.24"
 # DmaBufMemory downcast for the zero-copy VAAPI capture path.
 gstreamer-allocators = "^0.24"
+# fcntl(clear CLOEXEC) so the examples/vaapi_pipe_probe harness's per-cell
+# worker subprocesses inherit the portal pipewire fd. Present transitively;
+# declared for the diagnostic example.
+libc = "0.2"
 # Wayland output enumeration (xdg-output logical geometry) for the PipeWire/Wayland
 # capturable's stylus mapping. Gated to Linux, same as the rest of the Wayland path;
 # only exercised at runtime when the Wayland capture checkbox is enabled.
@@ -66,6 +70,9 @@ core-graphics = "^0.24"
 bench = []
 ffmpeg-system = []
 va-static = []
+# Diagnostic-only: compiles lib/vaapi_import_probe.c and enables the
+# examples/vaapi_pipe_probe harness. Never enabled for production builds.
+vaapi-probe = []
 
 [package.metadata.bundle]
 name = "Weylus"
@@ -84,3 +91,10 @@ assets = [
 [profile.release]
 lto = true
 opt-level = 3
+
+# Diagnostic-only zero-copy dmabuf -> VAAPI feasibility harness. Links the
+# lib/vaapi_import_probe.c backend that build.rs compiles under the same
+# feature. Run with: cargo run --example vaapi_pipe_probe --features vaapi-probe
+[[example]]
+name = "vaapi_pipe_probe"
+required-features = ["vaapi-probe"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,8 @@ dbus = "^0.9"
 gstreamer = "^0.24"
 gstreamer-app = { version = "^0.24", features = ["v1_16"] }
 gstreamer-video = "^0.24"
+# DmaBufMemory downcast for the zero-copy VAAPI capture path.
+gstreamer-allocators = "^0.24"
 # Wayland output enumeration (xdg-output logical geometry) for the PipeWire/Wayland
 # capturable's stylus mapping. Gated to Linux, same as the rest of the Wayland path;
 # only exercised at runtime when the Wayland capture checkbox is enabled.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,10 @@ dbus = "^0.9"
 gstreamer = "^0.24"
 gstreamer-app = { version = "^0.24", features = ["v1_16"] }
 gstreamer-video = "^0.24"
+# Wayland output enumeration (xdg-output logical geometry) for the PipeWire/Wayland
+# capturable's stylus mapping. Gated to Linux, same as the rest of the Wayland path;
+# only exercised at runtime when the Wayland capture checkbox is enabled.
+smithay-client-toolkit = "0.19"
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 pnet_datalink = "^0.35"

--- a/build.rs
+++ b/build.rs
@@ -98,6 +98,18 @@ fn main() {
     }
     cc_video.compile("video");
 
+    // Diagnostic-only VAAPI dmabuf-import probe (examples/vaapi_pipe_probe).
+    // Gated behind the `vaapi-probe` feature so normal builds never compile it.
+    // Links against the va/va-drm/drm + ffmpeg libs already emitted by linux().
+    if env::var("CARGO_FEATURE_VAAPI_PROBE").is_ok() && target_os == "linux" {
+        println!("cargo:rerun-if-changed=lib/vaapi_import_probe.c");
+        println!("cargo:rerun-if-changed=lib/vaapi_import_probe.h");
+        let mut cc_probe = cc::Build::new();
+        cc_probe.file("lib/vaapi_import_probe.c");
+        cc_probe.include(dist_dir.join("include"));
+        cc_probe.compile("vaapi_import_probe");
+    }
+
     println!("cargo:rerun-if-changed=lib/error.h");
     println!("cargo:rerun-if-changed=lib/error.c");
     println!("cargo:rerun-if-changed=lib/log.h");

--- a/examples/pw_probe.rs
+++ b/examples/pw_probe.rs
@@ -1,0 +1,675 @@
+// Standalone PipeWire screen-cast probe extracted from weylus.
+//
+// Purpose: reproduce ONLY the "portal ScreenCast -> GStreamer pipeline" path so the
+// GStreamer negotiation with the Wayland compositor (niri) can be debugged in isolation.
+// The only interactive step is clicking the source (e.g. DP-1) in the portal dialog once;
+// the probe then runs an automated pipeline/modifier test matrix against that single grant.
+//
+// Everything else (weylus web server, encoder, input) is intentionally omitted.
+//
+// Run:
+//   cargo run --example pw_probe
+//   GST_DEBUG=glupload:6,gleglimage:6 cargo run --example pw_probe   # GL import internals
+//   GST_DEBUG=pipewiresrc:5           cargo run --example pw_probe   # niri<->src negotiation
+//   PROBE_ALWAYS_COPY=1               cargo run --example pw_probe   # compare always-copy
+//   PROBE_ONLY=<substring>            cargo run --example pw_probe   # run one matrix entry
+// Edit the `matrix` in main() to change what gets tested.
+//
+// =============================================================================================
+// INVESTIGATION LOG  --  why weylus showed a black screen when capturing DP-1 on niri/Wayland,
+// and how this harness was used to find the fix. (Kept here so the reasoning survives with the
+// tool that produced it.)
+// =============================================================================================
+//
+// SYMPTOM
+//   Weylus streamed a black screen from a niri monitor. The GStreamer pipeline either failed to
+//   build, failed to reach PLAYING, or silently fell back to the X11/XWayland capturable (which
+//   cannot see native Wayland windows -> black).
+//
+// METHODOLOGY
+//   * GST_DEBUG *does* reach stderr from GStreamer here (an early wrong turn assumed it didn't --
+//     it was simply not set on some runs). gst-launch/this probe with GST_DEBUG is the fast loop;
+//     rebuilding all of weylus + driving a browser is not.
+//   * This probe copies weylus's portal (DBus) dance verbatim and exposes the raw fd + node id,
+//     then builds candidate pipelines directly. Reusing ONE portal grant to run a whole matrix
+//     of (converter chain x drm modifier) combinations is what made progress cheap: one DP-1
+//     click, ~8 hypotheses tested, each reporting negotiated caps + whether the resulting buffer
+//     actually CPU-maps to real pixels.
+//   * Evidence over guessing: every claim below was confirmed by a probe run or by reading the
+//     niri / pipewiresrc source (../niri-wts/niri-26.04, ../pipewire), not assumed.
+//
+// DISCOVERIES (each proven, not assumed)
+//   1. LINK BUG: weylus built the capsfilter with `drm-format=(list)< ... >`. `< >` is a
+//      GstValueArray (ordered tuple); a list of alternatives needs `{ }` (GstValueList). An
+//      array value does not intersect a list-valued `drm-format` sink pad, so `Element::link`
+//      failed with the generic "Failed to link elements". Verified with Caps::from_str +
+//      Element::link in isolation: `< >` -> GstValueArray -> FAIL, `{ }` -> GstValueList -> OK.
+//   2. FORMAT: for a MONITOR/output cast niri offers exactly ONE fourcc, XRGB8888 = `XR24`
+//      (niri mod.rs:409 passes alpha=false for outputs); ARGB8888 = `AR24` is window-only
+//      (alpha=true). vapostproc's DMABuf sink imports AB24/AR24/XB24 but NOT XR24 -> vapostproc
+//      can never work for a niri monitor. The intended importer is glupload (EGL dmabuf import).
+//   3. MODIFIER / MULTI-PLANE: niri defaults to a CCS modifier (Y_TILED_GEN12_MC_CCS,
+//      0x0100000000000008). CCS is multi-plane (colour buffer + a control-surface plane) but the
+//      screen-cast stream carries a SINGLE plane, so glupload's `eglCreateImage` fails with
+//      EGL_BAD_MATCH and it falls through to a CPU path that cannot map the buffer. Restricting
+//      the capsfilter to single-plane, non-CCS modifiers (LINEAR / X_TILED / Y_TILED) makes the
+//      EGL import succeed; the probe then gets full-size BGRx frames with real pixels. (LINEAR is
+//      written as the BARE fourcc `XR24`, not `XR24:0x0`; the ":0x0" spelling does not match.)
+//   4. always-copy: niri deliberately sets chunk->size = maxsize = 1 on its dmabufs (the real
+//      data lives in the fd; the size fields are dummy -- pw_utils.rs:743,1427). weylus set
+//      pipewiresrc `always-copy=true`, which makes pipewiresrc gst_memory_copy that "1 byte" into
+//      a 1-byte SYSTEM buffer, discarding the fd, so the GL importer has nothing to import. It
+//      MUST be false for the dmabuf path. (It was originally true for a teardown hang, pw#982;
+//      not observed on pipewire 1.7 across many probe teardowns.)
+//
+// WORKING PIPELINE (verified here: 5120x2160 BGRx, 44236800 bytes, buffer maps to real pixels)
+//   pipewiresrc(always-copy=false)
+//     -> capsfilter( video/x-raw(memory:DMABuf), DMA_DRM,
+//                    drm-format={ XR24, XR24:0x..01, XR24:0x..02,
+//                                 AR24, AR24:0x..01, AR24:0x..02 } )   // single-plane, no CCS
+//     -> glupload -> glcolorconvert -> gldownload -> videoconvert
+//     -> appsink(BGRx/RGBx)
+//   niri picks XR24@Y_TILED from that list (fast tiled path); glupload imports it via EGL.
+//   This is what src/capturable/pipewire.rs implements. vapostproc was a dead end (discovery 2).
+//
+// Intel DRM modifier reference (fourcc_mod_code(INTEL=0x01, n)):
+//   LINEAR = bare fourcc (mod 0)   X_TILED = 0x..01   Y_TILED = 0x..02
+//   RC_CCS = 0x..06 (multi-plane)  MC_CCS  = 0x..08 (multi-plane)  <- CCS ones break single-plane EGL import
+
+#[path = "../src/capturable/remote_desktop_dbus.rs"]
+mod remote_desktop_dbus;
+
+use std::collections::HashMap;
+use std::error::Error;
+use std::os::unix::io::AsRawFd;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use dbus::{
+    arg::{OwnedFd, PropMap, RefArg, Variant},
+    blocking::{Proxy, SyncConnection},
+    message::{MatchRule, MessageType},
+    Message,
+};
+
+use gstreamer as gst;
+use gstreamer::prelude::*;
+use gstreamer_app::AppSink;
+
+use remote_desktop_dbus::{
+    OrgFreedesktopPortalRemoteDesktop, OrgFreedesktopPortalRequestResponse,
+    OrgFreedesktopPortalScreenCast,
+};
+
+// ------------------------------------------------------------------------------------------------
+// Portal (DBus) dance — copied verbatim from src/capturable/pipewire.rs, with tracing macros
+// replaced by eprintln! so this is a self-contained binary.
+// ------------------------------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy)]
+struct PwStreamInfo {
+    path: u64,
+    source_type: u64,
+}
+
+#[derive(Debug)]
+struct DBusError(String);
+impl std::fmt::Display for DBusError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+impl Error for DBusError {}
+
+fn handle_response<F>(
+    portal: Proxy<&SyncConnection>,
+    path: dbus::Path<'static>,
+    context: Arc<Mutex<CallBackContext>>,
+    mut f: F,
+) -> Result<dbus::channel::Token, dbus::Error>
+where
+    F: FnMut(
+            OrgFreedesktopPortalRequestResponse,
+            Proxy<&SyncConnection>,
+            &Message,
+            Arc<Mutex<CallBackContext>>,
+        ) -> Result<(), Box<dyn Error>>
+        + Send
+        + Sync
+        + 'static,
+{
+    let mut m = MatchRule::new();
+    m.path = Some(path);
+    m.msg_type = Some(MessageType::Signal);
+    m.sender = Some("org.freedesktop.portal.Desktop".into());
+    m.interface = Some("org.freedesktop.portal.Request".into());
+    portal
+        .connection
+        .add_match(m, move |r: OrgFreedesktopPortalRequestResponse, c, m| {
+            let portal = get_portal(c);
+            eprintln!("[portal] response: {:?}", r.response);
+            let _ = m;
+            match r.response {
+                0 => {}
+                1 => {
+                    context.lock().unwrap().failure = true;
+                    eprintln!("[portal] User cancelled interaction.");
+                    return true;
+                }
+                c => {
+                    context.lock().unwrap().failure = true;
+                    eprintln!("[portal] Unknown error, code: {}.", c);
+                    return true;
+                }
+            }
+            if let Err(err) = f(r, portal, m, context.clone()) {
+                context.lock().unwrap().failure = true;
+                eprintln!("[portal] Error requesting screen capture via dbus: {}", err);
+            }
+            true
+        })
+}
+
+fn get_portal(conn: &SyncConnection) -> Proxy<'_, &SyncConnection> {
+    conn.with_proxy(
+        "org.freedesktop.portal.Desktop",
+        "/org/freedesktop/portal/desktop",
+        Duration::from_millis(1000),
+    )
+}
+
+fn streams_from_response(response: &OrgFreedesktopPortalRequestResponse) -> Vec<PwStreamInfo> {
+    (move || {
+        Some(
+            response
+                .results
+                .get("streams")?
+                .as_iter()?
+                .next()?
+                .as_iter()?
+                .filter_map(|stream| {
+                    let mut itr = stream.as_iter()?;
+                    let path = itr.next()?.as_u64()?;
+                    let (keys, values): (Vec<(usize, &dyn RefArg)>, Vec<(usize, &dyn RefArg)>) =
+                        itr.next()?
+                            .as_iter()?
+                            .enumerate()
+                            .partition(|(i, _)| i % 2 == 0);
+                    let attributes = keys
+                        .iter()
+                        .filter_map(|(_, key)| Some(key.as_str()?.to_owned()))
+                        .zip(
+                            values
+                                .iter()
+                                .map(|(_, arg)| *arg)
+                                .collect::<Vec<&dyn RefArg>>(),
+                        )
+                        .collect::<HashMap<String, &dyn RefArg>>();
+                    Some(PwStreamInfo {
+                        path,
+                        source_type: attributes
+                            .get("source_type")
+                            .map_or(Some(0), |v| v.as_u64())?,
+                    })
+                })
+                .collect::<Vec<PwStreamInfo>>(),
+        )
+    })()
+    .unwrap_or_default()
+}
+
+struct CallBackContext {
+    capture_cursor: bool,
+    session: dbus::Path<'static>,
+    streams: Vec<PwStreamInfo>,
+    fd: Option<OwnedFd>,
+    has_remote_desktop: bool,
+    failure: bool,
+}
+
+fn on_create_session_response(
+    r: OrgFreedesktopPortalRequestResponse,
+    portal: Proxy<&SyncConnection>,
+    _msg: &Message,
+    context: Arc<Mutex<CallBackContext>>,
+) -> Result<(), Box<dyn Error>> {
+    let session: dbus::Path = r
+        .results
+        .get("session_handle")
+        .ok_or_else(|| DBusError(format!("Failed to obtain session_handle: {:?}", r)))?
+        .as_str()
+        .ok_or_else(|| DBusError("Failed to convert session_handle to string.".into()))?
+        .to_string()
+        .into();
+
+    context.lock().unwrap().session = session.clone();
+    if context.lock().unwrap().has_remote_desktop {
+        select_devices(portal, context)
+    } else {
+        select_sources(portal, context)
+    }
+}
+
+fn select_devices(
+    portal: Proxy<&SyncConnection>,
+    context: Arc<Mutex<CallBackContext>>,
+) -> Result<(), Box<dyn Error>> {
+    let mut args: PropMap = HashMap::new();
+    let t: usize = rand::random();
+    args.insert(
+        "handle_token".to_string(),
+        Variant(Box::new(format!("weylus{t}"))),
+    );
+    args.insert("persist_mode".to_string(), Variant(Box::new(2u32)));
+    let device_types = portal.available_device_types()?;
+    args.insert("types".to_string(), Variant(Box::new(device_types)));
+    let path = portal.select_devices(context.lock().unwrap().session.clone(), args)?;
+    handle_response(portal, path, context, |_, portal, _, context| {
+        select_sources(portal, context)
+    })?;
+    Ok(())
+}
+
+fn select_sources(
+    portal: Proxy<&SyncConnection>,
+    context: Arc<Mutex<CallBackContext>>,
+) -> Result<(), Box<dyn Error>> {
+    let mut args: PropMap = HashMap::new();
+    let t: usize = rand::random();
+    args.insert(
+        "handle_token".to_string(),
+        Variant(Box::new(format!("weylus{t}"))),
+    );
+    args.insert("multiple".into(), Variant(Box::new(true)));
+    let source_types = portal.available_source_types()?;
+    args.insert("types".into(), Variant(Box::new(source_types)));
+    let capture_cursor = context.lock().unwrap().capture_cursor;
+    let cursor_mode = if capture_cursor { 2u32 } else { 1u32 };
+    args.insert("cursor_mode".into(), Variant(Box::new(cursor_mode)));
+    let path = portal.select_sources(context.lock().unwrap().session.clone(), args)?;
+    handle_response(portal, path, context, on_select_sources_response)?;
+    Ok(())
+}
+
+fn on_select_sources_response(
+    _r: OrgFreedesktopPortalRequestResponse,
+    portal: Proxy<&SyncConnection>,
+    _msg: &Message,
+    context: Arc<Mutex<CallBackContext>>,
+) -> Result<(), Box<dyn Error>> {
+    let mut args: PropMap = HashMap::new();
+    let t: usize = rand::random();
+    args.insert(
+        "handle_token".to_string(),
+        Variant(Box::new(format!("weylus{t}"))),
+    );
+    let path = if context.lock().unwrap().has_remote_desktop {
+        OrgFreedesktopPortalRemoteDesktop::start(
+            &portal,
+            context.lock().unwrap().session.clone(),
+            "",
+            args,
+        )?
+    } else {
+        OrgFreedesktopPortalScreenCast::start(
+            &portal,
+            context.lock().unwrap().session.clone(),
+            "",
+            args,
+        )?
+    };
+    handle_response(portal, path, context, on_start_response)?;
+    Ok(())
+}
+
+fn on_start_response(
+    r: OrgFreedesktopPortalRequestResponse,
+    portal: Proxy<&SyncConnection>,
+    _msg: &Message,
+    context: Arc<Mutex<CallBackContext>>,
+) -> Result<(), Box<dyn Error>> {
+    let mut context = context.lock().unwrap();
+    context.streams.append(&mut streams_from_response(&r));
+    let session = context.session.clone();
+    context
+        .fd
+        .replace(portal.open_pipe_wire_remote(session.clone(), HashMap::new())?);
+    eprintln!("[portal] Screen Cast Session started");
+    Ok(())
+}
+
+fn request_remote_desktop(
+    capture_cursor: bool,
+) -> Result<(SyncConnection, OwnedFd, Vec<PwStreamInfo>), Box<dyn Error>> {
+    let conn = SyncConnection::new_session()?;
+    let portal = get_portal(&conn);
+    let has_remote_desktop =
+        std::env::var("DESKTOP_SESSION").map_or(false, |s| s.contains("gnome"));
+
+    let context = CallBackContext {
+        capture_cursor,
+        session: Default::default(),
+        streams: Default::default(),
+        fd: None,
+        has_remote_desktop,
+        failure: false,
+    };
+    let context = Arc::new(Mutex::new(context));
+
+    let mut args: PropMap = HashMap::new();
+    let t1: usize = rand::random();
+    let t2: usize = rand::random();
+    args.insert(
+        "session_handle_token".to_string(),
+        Variant(Box::new(format!("weylus{t1}"))),
+    );
+    args.insert(
+        "handle_token".to_string(),
+        Variant(Box::new(format!("weylus{t2}"))),
+    );
+    let path = if has_remote_desktop {
+        OrgFreedesktopPortalRemoteDesktop::create_session(&portal, args)?
+    } else {
+        OrgFreedesktopPortalScreenCast::create_session(&portal, args)?
+    };
+    handle_response(portal, path, context.clone(), on_create_session_response)?;
+
+    eprintln!("[portal] waiting for you to pick a source in the portal dialog...");
+    for _ in 0..1800 {
+        conn.process(Duration::from_millis(100))?;
+        let ctx = context.lock().unwrap();
+        if ctx.fd.is_some() || ctx.failure {
+            break;
+        }
+    }
+    let ctx = context.lock().unwrap();
+    if ctx.fd.is_some() && !ctx.streams.is_empty() {
+        Ok((conn, ctx.fd.clone().unwrap(), ctx.streams.clone()))
+    } else {
+        Err(Box::new(DBusError("Failed to obtain screen capture.".into())))
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// Pipeline construction — the part under investigation.
+// ------------------------------------------------------------------------------------------------
+
+// A single test configuration: an optional capsfilter after pipewiresrc (`caps`,
+// empty = none) followed by a converter chain selected by `mode`.
+struct TestCfg {
+    label: &'static str,
+    mode: &'static str, // "convert" | "glupload" | "vpp"
+    caps: String,
+}
+
+// niri (monitor cast) offers ONLY XRGB8888 (XR24). Build a dmabuf capsfilter for XR24
+// restricted to the given modifier(s). `mods` is a list of "XR24:<modifier>" fourcc:mod
+// strings joined into a GstValueList.
+fn xr24_caps(mods: &[&str]) -> String {
+    let list = mods
+        .iter()
+        .map(|m| format!("(string){m}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        "video/x-raw(memory:DMABuf), format=(string)DMA_DRM, width=(int)[1,32767], \
+         height=(int)[1,32767], framerate=(fraction)[0/1,2147483647/1], \
+         drm-format=(list){{ {list} }}"
+    )
+}
+
+fn build_pipeline(
+    fd: i32,
+    path: u64,
+    cfg: &TestCfg,
+) -> Result<(gst::Pipeline, AppSink), Box<dyn Error>> {
+    let pipeline = gst::Pipeline::new();
+
+    let src = gst::ElementFactory::make("pipewiresrc").build()?;
+    src.set_property("fd", &fd);
+    src.set_property("path", &format!("{}", path));
+    let always_copy = std::env::var("PROBE_ALWAYS_COPY").map(|v| v == "1" || v == "true").unwrap_or(false);
+    src.set_property("always-copy", &always_copy);
+
+    let sink = gst::ElementFactory::make("appsink").build()?;
+    sink.set_property("drop", &true);
+    sink.set_property("max-buffers", &1u32);
+
+    let make = |n: &str| gst::ElementFactory::make(n).build();
+
+    let mut elements: Vec<gst::Element> = vec![src.clone()];
+    if !cfg.caps.is_empty() {
+        let cf = make("capsfilter")?;
+        cf.set_property("caps", &cfg.caps.parse::<gst::Caps>()?);
+        elements.push(cf);
+    }
+    match cfg.mode {
+        "glupload" => {
+            elements.push(make("glupload")?);
+            elements.push(make("glcolorconvert")?);
+            elements.push(make("gldownload")?);
+            elements.push(make("videoconvert")?);
+        }
+        "vpp" => {
+            elements.push(make("vapostproc")?);
+            elements.push(make("videoconvert")?);
+        }
+        // "dmabuf": no converter at all — appsink receives the dmabuf directly and we
+        // mmap it ourselves (works only for LINEAR: a tiled/CCS buffer maps to garbage).
+        "dmabuf" => {}
+        // "convert": rely on videoconvert to consume the (dmabuf) buffer directly
+        _ => {
+            elements.push(make("videoconvert")?);
+        }
+    }
+    elements.push(sink.clone());
+
+    pipeline.add_many(&elements)?;
+    for w in elements.windows(2) {
+        w[0].link(&w[1]).map_err(|e| {
+            DBusError(format!("link {} -> {} failed: {e}", w[0].name(), w[1].name()))
+        })?;
+    }
+
+    let appsink = sink
+        .dynamic_cast::<AppSink>()
+        .map_err(|_| DBusError("sink is not an appsink".into()))?;
+    if cfg.mode == "dmabuf" {
+        // Accept the dmabuf straight through; format stays DMA_DRM in caps.
+        let c: gst::Caps = "video/x-raw(memory:DMABuf)".parse()?;
+        appsink.set_caps(Some(&c));
+    } else {
+        let mut caps = gst::Caps::new_empty();
+        caps.merge_structure(gst::structure::Structure::from_iter(
+            "video/x-raw",
+            [("format", "BGRx".into())],
+        ));
+        caps.merge_structure(gst::structure::Structure::from_iter(
+            "video/x-raw",
+            [("format", "RGBx".into())],
+        ));
+        appsink.set_caps(Some(&caps));
+    }
+
+    Ok((pipeline, appsink))
+}
+
+// Build+run one config against an already-open portal fd/node. Returns a short verdict.
+fn run_one(fd: i32, path: u64, cfg: &TestCfg) -> String {
+    eprintln!("\n================ TEST: {} (mode={}) ================", cfg.label, cfg.mode);
+    if !cfg.caps.is_empty() {
+        eprintln!("  capsfilter: {}", cfg.caps);
+    }
+    let (pipeline, appsink) = match build_pipeline(fd, path, cfg) {
+        Ok(x) => x,
+        Err(e) => {
+            eprintln!("  build/link error: {e}");
+            return format!("{}: BUILD-FAIL ({e})", cfg.label);
+        }
+    };
+
+    let start = pipeline.set_state(gst::State::Playing);
+    let failed = match start {
+        Err(_) => true,
+        Ok(gst::StateChangeSuccess::Async) => {
+            pipeline.state(gst::ClockTime::from_seconds(4)).0.is_err()
+        }
+        Ok(_) => false,
+    };
+
+    if failed {
+        let err = drain_bus_errors(&pipeline);
+        eprintln!("  FAILED to start:\n  {err}");
+        let _ = pipeline.set_state(gst::State::Null);
+        let short = err.lines().next().unwrap_or("").to_string();
+        return format!("{}: START-FAIL ({short})", cfg.label);
+    }
+
+    let mut negotiated = String::from("?");
+    if let Some(srcel) = pipeline.by_name("pipewiresrc0") {
+        if let Some(pad) = srcel.static_pad("src") {
+            if let Some(c) = pad.current_caps() {
+                negotiated = c.to_string();
+            }
+        }
+    }
+    eprintln!("  negotiated (pipewiresrc src): {negotiated}");
+
+    let mut got = 0;
+    let mut sample_info = String::new();
+    for _ in 0..40 {
+        if let Some(sample) = appsink.try_pull_sample(gst::ClockTime::from_mseconds(100)) {
+            let caps = sample.caps().unwrap();
+            let st = caps.structure(0).unwrap();
+            let w: i32 = st.value("width").ok().and_then(|v| v.get().ok()).unwrap_or(-1);
+            let h: i32 = st.value("height").ok().and_then(|v| v.get().ok()).unwrap_or(-1);
+            let fmt: String = st.value("format").ok().and_then(|v| v.get().ok()).unwrap_or_else(|| "?".into());
+            let drm: String = st.value("drm-format").ok().and_then(|v| v.get().ok()).unwrap_or_else(|| "-".into());
+            let expect = w as usize * h as usize * 4;
+            // Actually try to CPU-map the buffer (this is what weylus does).
+            let buf = sample.buffer_owned().unwrap();
+            let bufsz = buf.size();
+            // Introspect memory layout.
+            let nmem = buf.n_memory();
+            let mut mem_desc = Vec::new();
+            for mi in 0..nmem {
+                if let Some(m) = buf.memory(mi) {
+                    mem_desc.push(format!("mem{mi}:size={}", m.size()));
+                }
+            }
+            eprintln!("  buffer: n_memory={nmem} [{}]", mem_desc.join(", "));
+            let map_report = match buf.into_mapped_buffer_readable() {
+                Ok(mapped) => {
+                    let s = mapped.as_slice();
+                    let head: Vec<String> = s.iter().take(12).map(|b| format!("{b:02x}")).collect();
+                    // crude "is it real pixels" check: not all identical
+                    let all_same = s.iter().take(4096).all(|&b| b == s[0]);
+                    format!(
+                        "MAPPED {} bytes, head=[{}]{}",
+                        s.len(),
+                        head.join(" "),
+                        if all_same { " (looks uniform/blank)" } else { " (varied -> real pixels)" }
+                    )
+                }
+                Err(_) => "MAP FAILED (not CPU-accessible)".to_string(),
+            };
+            sample_info = format!("{w}x{h} fmt={fmt} drm={drm} buf={bufsz} (expect {expect}); {map_report}");
+            eprintln!("  frame: {sample_info}");
+            got += 1;
+            if got >= 3 {
+                break;
+            }
+        }
+    }
+
+    let _ = pipeline.set_state(gst::State::Null);
+    // Give pipewiresrc a moment to fully release the node before the next test reconnects.
+    std::thread::sleep(Duration::from_millis(300));
+
+    if got > 0 {
+        eprintln!("  ==> SUCCESS ({got} frames)");
+        format!("{}: OK ({sample_info})", cfg.label)
+    } else {
+        let err = drain_bus_errors(&pipeline);
+        eprintln!("  ==> started but NO frames. {err}");
+        format!("{}: NO-FRAMES", cfg.label)
+    }
+}
+
+fn drain_bus_errors(pipeline: &gst::Pipeline) -> String {
+    let bus = match pipeline.bus() {
+        Some(b) => b,
+        None => return "no bus".into(),
+    };
+    let mut msgs = Vec::new();
+    while let Some(msg) =
+        bus.timed_pop_filtered(gst::ClockTime::from_mseconds(800), &[gst::MessageType::Error])
+    {
+        if let gst::MessageView::Error(err) = msg.view() {
+            let src = err
+                .src()
+                .map(|s| s.path_string().to_string())
+                .unwrap_or_else(|| "?".into());
+            msgs.push(format!(
+                "[{src}] {} (debug: {})",
+                err.error(),
+                err.debug().unwrap_or_else(|| "none".into())
+            ));
+        }
+    }
+    if msgs.is_empty() {
+        "no error message on bus".into()
+    } else {
+        msgs.join("\n  ")
+    }
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    gst::init()?;
+
+    // EXACT caps weylus now uses (single-plane, non-CCS; XR24 for monitor, AR24 for window).
+    let weylus_caps = "video/x-raw(memory:DMABuf), format=(string)DMA_DRM, \
+         width=(int)[1,32767], height=(int)[1,32767], \
+         framerate=(fraction)[0/1,2147483647/1], drm-format=(list){ \
+         (string)XR24, (string)XR24:0x0100000000000001, (string)XR24:0x0100000000000002, \
+         (string)AR24, (string)AR24:0x0100000000000001, (string)AR24:0x0100000000000002 }"
+        .to_string();
+
+    // Validate the exact weylus pipeline (one DP-1 click).
+    let matrix = vec![
+        TestCfg { label: "WEYLUS caps -> glupload chain", mode: "glupload", caps: weylus_caps },
+    ];
+
+    let (conn, fd, streams) = request_remote_desktop(false)?;
+    eprintln!("[portal] got fd={} and {} stream(s):", fd.as_raw_fd(), streams.len());
+    for s in &streams {
+        eprintln!("    node path={} source_type={}", s.path, s.source_type);
+    }
+    let stream = streams
+        .iter()
+        .find(|s| s.source_type == 1)
+        .copied()
+        .unwrap_or(streams[0]);
+    eprintln!("[probe] using node path={}", stream.path);
+
+    // Allow running a single named test via PROBE_ONLY=<substring> for focused reruns.
+    let only = std::env::var("PROBE_ONLY").ok();
+
+    let mut verdicts = Vec::new();
+    for cfg in &matrix {
+        if let Some(f) = &only {
+            if !cfg.label.contains(f.as_str()) {
+                continue;
+            }
+        }
+        verdicts.push(run_one(fd.as_raw_fd(), stream.path, cfg));
+    }
+
+    eprintln!("\n\n================ SUMMARY ================");
+    for v in &verdicts {
+        eprintln!("  {v}");
+    }
+
+    drop(conn);
+    Ok(())
+}

--- a/examples/vaapi_pipe_probe.rs
+++ b/examples/vaapi_pipe_probe.rs
@@ -1,0 +1,984 @@
+// Standalone VAAPI zero-copy feasibility probe. Build/run:
+//   devenv shell -- cargo run --example vaapi_pipe_probe --features vaapi-probe
+//
+// Reuses ONE portal ScreenCast grant (you pick a monitor once), then runs a
+// (import-path x drm-modifier) matrix all the way to an encoded H264 frame to
+// find out whether a GPU-resident niri-dmabuf -> VAAPI path is possible.
+
+#[path = "../src/capturable/remote_desktop_dbus.rs"]
+mod remote_desktop_dbus;
+
+use std::collections::HashMap;
+use std::error::Error;
+use std::os::raw::c_int;
+use std::os::unix::io::AsRawFd;
+use std::process::{Command, Stdio};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use dbus::{
+    arg::{OwnedFd, PropMap, RefArg, Variant},
+    blocking::{Proxy, SyncConnection},
+    message::{MatchRule, MessageType},
+    Message,
+};
+
+use gstreamer as gst;
+use gstreamer::prelude::*;
+use gstreamer_app::AppSink;
+use gstreamer_video::VideoMeta;
+
+use remote_desktop_dbus::{
+    OrgFreedesktopPortalRemoteDesktop, OrgFreedesktopPortalRequestResponse,
+    OrgFreedesktopPortalScreenCast,
+};
+
+extern "C" {
+    fn vaapi_probe_selftest() -> c_int;
+    fn vaapi_probe_encode_dmabuf(
+        dmabuf_fd: c_int,
+        width: u32,
+        height: u32,
+        drm_fourcc: u32,
+        drm_modifier: u64,
+        stride: u32,
+        offset: u32,
+        reason: *mut u8,
+        reason_len: c_int,
+    ) -> c_int;
+}
+
+/// DRM fourcc for XR24 (DRM_FORMAT_XRGB8888) = 'X','R','2','4' little-endian.
+fn xr24_fourcc() -> u32 {
+    u32::from_le_bytes([b'X', b'R', b'2', b'4'])
+}
+
+// ------------------------------------------------------------------------------------------------
+// Portal (DBus) dance — copied verbatim from src/capturable/pipewire.rs, with tracing macros
+// replaced by eprintln! so this is a self-contained binary.
+// ------------------------------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy)]
+struct PwStreamInfo {
+    path: u64,
+    source_type: u64,
+}
+
+#[derive(Debug)]
+struct DBusError(String);
+impl std::fmt::Display for DBusError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+impl Error for DBusError {}
+
+fn handle_response<F>(
+    portal: Proxy<&SyncConnection>,
+    path: dbus::Path<'static>,
+    context: Arc<Mutex<CallBackContext>>,
+    mut f: F,
+) -> Result<dbus::channel::Token, dbus::Error>
+where
+    F: FnMut(
+            OrgFreedesktopPortalRequestResponse,
+            Proxy<&SyncConnection>,
+            &Message,
+            Arc<Mutex<CallBackContext>>,
+        ) -> Result<(), Box<dyn Error>>
+        + Send
+        + Sync
+        + 'static,
+{
+    let mut m = MatchRule::new();
+    m.path = Some(path);
+    m.msg_type = Some(MessageType::Signal);
+    m.sender = Some("org.freedesktop.portal.Desktop".into());
+    m.interface = Some("org.freedesktop.portal.Request".into());
+    portal
+        .connection
+        .add_match(m, move |r: OrgFreedesktopPortalRequestResponse, c, m| {
+            let portal = get_portal(c);
+            eprintln!("[portal] response: {:?}", r.response);
+            let _ = m;
+            match r.response {
+                0 => {}
+                1 => {
+                    context.lock().unwrap().failure = true;
+                    eprintln!("[portal] User cancelled interaction.");
+                    return true;
+                }
+                c => {
+                    context.lock().unwrap().failure = true;
+                    eprintln!("[portal] Unknown error, code: {}.", c);
+                    return true;
+                }
+            }
+            if let Err(err) = f(r, portal, m, context.clone()) {
+                context.lock().unwrap().failure = true;
+                eprintln!("[portal] Error requesting screen capture via dbus: {}", err);
+            }
+            true
+        })
+}
+
+fn get_portal(conn: &SyncConnection) -> Proxy<'_, &SyncConnection> {
+    conn.with_proxy(
+        "org.freedesktop.portal.Desktop",
+        "/org/freedesktop/portal/desktop",
+        Duration::from_millis(1000),
+    )
+}
+
+fn streams_from_response(response: &OrgFreedesktopPortalRequestResponse) -> Vec<PwStreamInfo> {
+    (move || {
+        Some(
+            response
+                .results
+                .get("streams")?
+                .as_iter()?
+                .next()?
+                .as_iter()?
+                .filter_map(|stream| {
+                    let mut itr = stream.as_iter()?;
+                    let path = itr.next()?.as_u64()?;
+                    let (keys, values): (Vec<(usize, &dyn RefArg)>, Vec<(usize, &dyn RefArg)>) =
+                        itr.next()?
+                            .as_iter()?
+                            .enumerate()
+                            .partition(|(i, _)| i % 2 == 0);
+                    let attributes = keys
+                        .iter()
+                        .filter_map(|(_, key)| Some(key.as_str()?.to_owned()))
+                        .zip(
+                            values
+                                .iter()
+                                .map(|(_, arg)| *arg)
+                                .collect::<Vec<&dyn RefArg>>(),
+                        )
+                        .collect::<HashMap<String, &dyn RefArg>>();
+                    Some(PwStreamInfo {
+                        path,
+                        source_type: attributes
+                            .get("source_type")
+                            .map_or(Some(0), |v| v.as_u64())?,
+                    })
+                })
+                .collect::<Vec<PwStreamInfo>>(),
+        )
+    })()
+    .unwrap_or_default()
+}
+
+struct CallBackContext {
+    capture_cursor: bool,
+    session: dbus::Path<'static>,
+    streams: Vec<PwStreamInfo>,
+    fd: Option<OwnedFd>,
+    has_remote_desktop: bool,
+    failure: bool,
+}
+
+fn on_create_session_response(
+    r: OrgFreedesktopPortalRequestResponse,
+    portal: Proxy<&SyncConnection>,
+    _msg: &Message,
+    context: Arc<Mutex<CallBackContext>>,
+) -> Result<(), Box<dyn Error>> {
+    let session: dbus::Path = r
+        .results
+        .get("session_handle")
+        .ok_or_else(|| DBusError(format!("Failed to obtain session_handle: {:?}", r)))?
+        .as_str()
+        .ok_or_else(|| DBusError("Failed to convert session_handle to string.".into()))?
+        .to_string()
+        .into();
+
+    context.lock().unwrap().session = session.clone();
+    if context.lock().unwrap().has_remote_desktop {
+        select_devices(portal, context)
+    } else {
+        select_sources(portal, context)
+    }
+}
+
+fn select_devices(
+    portal: Proxy<&SyncConnection>,
+    context: Arc<Mutex<CallBackContext>>,
+) -> Result<(), Box<dyn Error>> {
+    let mut args: PropMap = HashMap::new();
+    let t: usize = rand::random();
+    args.insert(
+        "handle_token".to_string(),
+        Variant(Box::new(format!("weylus{t}"))),
+    );
+    args.insert("persist_mode".to_string(), Variant(Box::new(2u32)));
+    let device_types = portal.available_device_types()?;
+    args.insert("types".to_string(), Variant(Box::new(device_types)));
+    let path = portal.select_devices(context.lock().unwrap().session.clone(), args)?;
+    handle_response(portal, path, context, |_, portal, _, context| {
+        select_sources(portal, context)
+    })?;
+    Ok(())
+}
+
+fn select_sources(
+    portal: Proxy<&SyncConnection>,
+    context: Arc<Mutex<CallBackContext>>,
+) -> Result<(), Box<dyn Error>> {
+    let mut args: PropMap = HashMap::new();
+    let t: usize = rand::random();
+    args.insert(
+        "handle_token".to_string(),
+        Variant(Box::new(format!("weylus{t}"))),
+    );
+    args.insert("multiple".into(), Variant(Box::new(true)));
+    let source_types = portal.available_source_types()?;
+    args.insert("types".into(), Variant(Box::new(source_types)));
+    let capture_cursor = context.lock().unwrap().capture_cursor;
+    let cursor_mode = if capture_cursor { 2u32 } else { 1u32 };
+    args.insert("cursor_mode".into(), Variant(Box::new(cursor_mode)));
+    let path = portal.select_sources(context.lock().unwrap().session.clone(), args)?;
+    handle_response(portal, path, context, on_select_sources_response)?;
+    Ok(())
+}
+
+fn on_select_sources_response(
+    _r: OrgFreedesktopPortalRequestResponse,
+    portal: Proxy<&SyncConnection>,
+    _msg: &Message,
+    context: Arc<Mutex<CallBackContext>>,
+) -> Result<(), Box<dyn Error>> {
+    let mut args: PropMap = HashMap::new();
+    let t: usize = rand::random();
+    args.insert(
+        "handle_token".to_string(),
+        Variant(Box::new(format!("weylus{t}"))),
+    );
+    let path = if context.lock().unwrap().has_remote_desktop {
+        OrgFreedesktopPortalRemoteDesktop::start(
+            &portal,
+            context.lock().unwrap().session.clone(),
+            "",
+            args,
+        )?
+    } else {
+        OrgFreedesktopPortalScreenCast::start(
+            &portal,
+            context.lock().unwrap().session.clone(),
+            "",
+            args,
+        )?
+    };
+    handle_response(portal, path, context, on_start_response)?;
+    Ok(())
+}
+
+fn on_start_response(
+    r: OrgFreedesktopPortalRequestResponse,
+    portal: Proxy<&SyncConnection>,
+    _msg: &Message,
+    context: Arc<Mutex<CallBackContext>>,
+) -> Result<(), Box<dyn Error>> {
+    let mut context = context.lock().unwrap();
+    context.streams.append(&mut streams_from_response(&r));
+    let session = context.session.clone();
+    context
+        .fd
+        .replace(portal.open_pipe_wire_remote(session.clone(), HashMap::new())?);
+    eprintln!("[portal] Screen Cast Session started");
+    Ok(())
+}
+
+fn request_remote_desktop(
+    capture_cursor: bool,
+) -> Result<(SyncConnection, OwnedFd, Vec<PwStreamInfo>), Box<dyn Error>> {
+    let conn = SyncConnection::new_session()?;
+    let portal = get_portal(&conn);
+    let has_remote_desktop =
+        std::env::var("DESKTOP_SESSION").map_or(false, |s| s.contains("gnome"));
+
+    let context = CallBackContext {
+        capture_cursor,
+        session: Default::default(),
+        streams: Default::default(),
+        fd: None,
+        has_remote_desktop,
+        failure: false,
+    };
+    let context = Arc::new(Mutex::new(context));
+
+    let mut args: PropMap = HashMap::new();
+    let t1: usize = rand::random();
+    let t2: usize = rand::random();
+    args.insert(
+        "session_handle_token".to_string(),
+        Variant(Box::new(format!("weylus{t1}"))),
+    );
+    args.insert(
+        "handle_token".to_string(),
+        Variant(Box::new(format!("weylus{t2}"))),
+    );
+    let path = if has_remote_desktop {
+        OrgFreedesktopPortalRemoteDesktop::create_session(&portal, args)?
+    } else {
+        OrgFreedesktopPortalScreenCast::create_session(&portal, args)?
+    };
+    handle_response(portal, path, context.clone(), on_create_session_response)?;
+
+    eprintln!("[portal] waiting for you to pick a source in the portal dialog...");
+    for _ in 0..1800 {
+        conn.process(Duration::from_millis(100))?;
+        let ctx = context.lock().unwrap();
+        if ctx.fd.is_some() || ctx.failure {
+            break;
+        }
+    }
+    let ctx = context.lock().unwrap();
+    if ctx.fd.is_some() && !ctx.streams.is_empty() {
+        Ok((conn, ctx.fd.clone().unwrap(), ctx.streams.clone()))
+    } else {
+        Err(Box::new(DBusError("Failed to obtain screen capture.".into())))
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// Matrix model: import-path x drm-modifier.
+// ------------------------------------------------------------------------------------------------
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum ImportPath {
+    DirectVa,
+    GlToVa,
+    FfmpegImport,
+    CpuControl,
+}
+
+impl ImportPath {
+    fn short(&self) -> &'static str {
+        match self {
+            ImportPath::DirectVa => "A/direct-va",
+            ImportPath::GlToVa => "B/gl-to-va",
+            ImportPath::FfmpegImport => "C/ffmpeg-import",
+            ImportPath::CpuControl => "D/cpu-control",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Modifier {
+    name: &'static str,
+    drm: u64,
+}
+
+const MODIFIERS: [Modifier; 4] = [
+    Modifier { name: "LINEAR", drm: 0x0 },
+    Modifier { name: "X_TILED", drm: 0x0100000000000001 },
+    Modifier { name: "Y_TILED", drm: 0x0100000000000002 },
+    Modifier { name: "Y_TILED_CCS", drm: 0x0100000000000008 },
+];
+
+const PATHS: [ImportPath; 4] = [
+    ImportPath::DirectVa,
+    ImportPath::GlToVa,
+    ImportPath::FfmpegImport,
+    ImportPath::CpuControl,
+];
+
+#[derive(Clone, Copy)]
+struct Cell {
+    path: ImportPath,
+    modifier: Modifier,
+}
+
+fn all_cells() -> Vec<Cell> {
+    let mut v = Vec::with_capacity(16);
+    for path in PATHS {
+        for modifier in MODIFIERS {
+            v.push(Cell { path, modifier });
+        }
+    }
+    v
+}
+
+fn drm_fourcc_mod_string(m: &Modifier) -> String {
+    if m.drm == 0 {
+        "XR24".to_string()
+    } else {
+        format!("XR24:{:#018x}", m.drm)
+    }
+}
+
+fn xr24_caps(mods: &[&str]) -> String {
+    let list = mods
+        .iter()
+        .map(|m| format!("(string){m}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        "video/x-raw(memory:DMABuf), format=(string)DMA_DRM, \
+         width=(int)[1,32767], height=(int)[1,32767], \
+         framerate=(fraction)[0/1,2147483647/1], \
+         drm-format=(list){{ {list} }}"
+    )
+}
+
+fn cell_label(c: &Cell) -> String {
+    format!("{}/{}", c.path.short(), c.modifier.name)
+}
+
+fn cell_enabled(c: &Cell) -> bool {
+    match std::env::var("PROBE_ONLY") {
+        Ok(s) if !s.is_empty() => cell_label(c).contains(&s),
+        _ => true,
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+// Per-cell runner: build a fresh pipeline, drive to first frame, time ~30 frames.
+// ------------------------------------------------------------------------------------------------
+
+#[derive(Default, Clone)]
+struct CellResult {
+    label: String,
+    ok: bool,
+    first_frame_bytes: usize,
+    avg_ms: f64,
+    first_latency_ms: f64,
+    negotiated: String,
+    reason: String,
+}
+
+fn mk(name: &str) -> Result<gst::Element, Box<dyn Error>> {
+    gst::ElementFactory::make(name)
+        .build()
+        .map_err(|e| Box::new(DBusError(format!("make {name}: {e}"))) as Box<dyn Error>)
+}
+
+fn h264_appsink() -> Result<AppSink, Box<dyn Error>> {
+    let s = mk("appsink")?;
+    s.set_property("drop", &true);
+    s.set_property("max-buffers", &1u32);
+    let a = s
+        .dynamic_cast::<AppSink>()
+        .map_err(|_| DBusError("not appsink".into()))?;
+    a.set_caps(Some(&"video/x-h264".parse::<gst::Caps>()?));
+    Ok(a)
+}
+
+fn bgrx_appsink() -> Result<AppSink, Box<dyn Error>> {
+    let s = mk("appsink")?;
+    s.set_property("drop", &true);
+    s.set_property("max-buffers", &1u32);
+    let a = s
+        .dynamic_cast::<AppSink>()
+        .map_err(|_| DBusError("not appsink".into()))?;
+    let mut caps = gst::Caps::new_empty();
+    caps.merge_structure(gst::structure::Structure::from_iter(
+        "video/x-raw",
+        [("format", "BGRx".into())],
+    ));
+    caps.merge_structure(gst::structure::Structure::from_iter(
+        "video/x-raw",
+        [("format", "RGBx".into())],
+    ));
+    a.set_caps(Some(&caps));
+    Ok(a)
+}
+
+// Returns (pipeline, appsink, is_h264_sink). Handles A/B/D; C is run elsewhere.
+fn build_gst_pipeline(
+    fd: i32,
+    node: u64,
+    cell: &Cell,
+) -> Result<(gst::Pipeline, AppSink, bool), Box<dyn Error>> {
+    let pipeline = gst::Pipeline::new();
+    let src = mk("pipewiresrc")?;
+    src.set_property("fd", &fd);
+    src.set_property("path", &format!("{node}"));
+    // A/B/D all consume the GPU dmabuf; never copy it to a 1-byte sysmem buffer.
+    src.set_property("always-copy", &false);
+
+    // A modifier-forcing capsfilter for the paths that sweep modifiers (B, D).
+    // Path A deliberately omits it: we let pipewiresrc and vapostproc negotiate
+    // freely, so a failure proves niri's format is fundamentally unacceptable to
+    // the VA element (not just that we over-constrained the caps).
+    let capsfilter = || -> Result<gst::Element, Box<dyn Error>> {
+        let cf = mk("capsfilter")?;
+        cf.set_property(
+            "caps",
+            &xr24_caps(&[&drm_fourcc_mod_string(&cell.modifier)]).parse::<gst::Caps>()?,
+        );
+        Ok(cf)
+    };
+
+    let mut chain: Vec<gst::Element> = vec![src];
+    let is_h264;
+    let sink;
+
+    match cell.path {
+        ImportPath::DirectVa => {
+            // Free negotiation — no capsfilter.
+            chain.push(mk("vapostproc")?);
+            chain.push(mk("vah264enc").or_else(|_| mk("vah264lpenc"))?);
+            sink = h264_appsink()?;
+            is_h264 = true;
+        }
+        ImportPath::GlToVa => {
+            chain.push(capsfilter()?);
+            chain.push(mk("glupload")?);
+            chain.push(mk("glcolorconvert")?);
+            chain.push(mk("vapostproc")?);
+            chain.push(mk("vah264enc").or_else(|_| mk("vah264lpenc"))?);
+            sink = h264_appsink()?;
+            is_h264 = true;
+        }
+        ImportPath::CpuControl => {
+            chain.push(capsfilter()?);
+            chain.push(mk("glupload")?);
+            chain.push(mk("glcolorconvert")?);
+            chain.push(mk("gldownload")?);
+            chain.push(mk("videoconvert")?);
+            sink = bgrx_appsink()?;
+            is_h264 = false;
+        }
+        ImportPath::FfmpegImport => {
+            return Err(Box::new(DBusError("path C handled by run_ffmpeg_cell".into())));
+        }
+    }
+
+    chain.push(sink.clone().upcast::<gst::Element>());
+    pipeline.add_many(&chain)?;
+    for w in chain.windows(2) {
+        w[0].link(&w[1]).map_err(|e| {
+            DBusError(format!("link {} -> {}: {e}", w[0].name(), w[1].name()))
+        })?;
+    }
+    Ok((pipeline, sink, is_h264))
+}
+
+fn drain_bus(pipeline: &gst::Pipeline) -> String {
+    let bus = match pipeline.bus() {
+        Some(b) => b,
+        None => return "no bus".into(),
+    };
+    let mut msgs = Vec::new();
+    while let Some(msg) =
+        bus.timed_pop_filtered(gst::ClockTime::from_mseconds(300), &[gst::MessageType::Error])
+    {
+        if let gst::MessageView::Error(err) = msg.view() {
+            msgs.push(format!(
+                "{} ({})",
+                err.error(),
+                err.debug().unwrap_or_else(|| "none".into())
+            ));
+        }
+    }
+    if msgs.is_empty() {
+        "no error on bus".into()
+    } else {
+        msgs.join("; ")
+    }
+}
+
+fn run_gst_cell(fd: i32, node: u64, cell: &Cell) -> CellResult {
+    let label = cell_label(cell);
+    let mut r = CellResult {
+        label: label.clone(),
+        ..Default::default()
+    };
+
+    let (pipeline, appsink, is_h264) = match build_gst_pipeline(fd, node, cell) {
+        Ok(t) => t,
+        Err(e) => {
+            r.reason = format!("build: {e}");
+            return r;
+        }
+    };
+
+    if pipeline.set_state(gst::State::Playing).is_err() {
+        r.reason = format!("set_state(Playing) failed: {}", drain_bus(&pipeline));
+        let _ = pipeline.set_state(gst::State::Null);
+        return r;
+    }
+    // Wait for preroll / async state change.
+    let _ = pipeline.state(gst::ClockTime::from_seconds(5));
+
+    let t0 = Instant::now();
+    let first = appsink.try_pull_sample(gst::ClockTime::from_seconds(5));
+    let first_latency = t0.elapsed().as_secs_f64() * 1000.0;
+    let sample = match first {
+        Some(s) => s,
+        None => {
+            r.reason = format!("no frame in 5s: {}", drain_bus(&pipeline));
+            let _ = pipeline.set_state(gst::State::Null);
+            return r;
+        }
+    };
+
+    r.negotiated = sample.caps().map(|c| c.to_string()).unwrap_or_default();
+    r.first_frame_bytes = sample.buffer().map(|b| b.size()).unwrap_or(0);
+    // For the D control (raw BGRx), a produced frame means capture works; the
+    // encode side is exercised by A/B/C. For A/B this is already an H264 packet.
+    let _ = is_h264;
+
+    // Time ~30 more pulls.
+    let mut n = 0u32;
+    let tstart = Instant::now();
+    while n < 30 {
+        if appsink
+            .try_pull_sample(gst::ClockTime::from_mseconds(200))
+            .is_some()
+        {
+            n += 1;
+        } else {
+            break;
+        }
+    }
+    if n > 0 {
+        r.avg_ms = tstart.elapsed().as_secs_f64() * 1000.0 / n as f64;
+    }
+    r.first_latency_ms = first_latency;
+    r.ok = true;
+
+    let _ = pipeline.set_state(gst::State::Null);
+    std::thread::sleep(Duration::from_millis(300)); // pw#982 node release
+    r
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    if std::env::args().any(|a| a == "--dry-run") {
+        for c in all_cells().into_iter().filter(cell_enabled) {
+            println!(
+                "cell {:22}  drm-format={}",
+                cell_label(&c),
+                drm_fourcc_mod_string(&c.modifier)
+            );
+        }
+        return Ok(());
+    }
+
+    // Worker mode: run exactly ONE cell against an inherited pipewire fd, print a
+    // machine-readable RESULT line, and exit. Each cell runs in its own process so
+    // a GL/VA crash (libgstgl _gl_mem_create, seen under niri) kills only that cell
+    // and cannot corrupt GL/VA global state for the others. A crashed worker is
+    // reported as `worker crashed` — never mistaken for a negotiation verdict.
+    if let Ok(id) = std::env::var("PROBE_RUN_ONE") {
+        return run_worker(&id);
+    }
+
+    // Coordinator: acquire one portal grant, then spawn a worker per enabled cell.
+    eprintln!("[portal] a desktop portal dialog will open — pick a MONITOR to cast.");
+    let (_conn, fd, streams) = request_remote_desktop(false)?;
+    let node = streams
+        .iter()
+        .find(|s| s.source_type == 1)
+        .or_else(|| streams.first())
+        .map(|s| s.path)
+        .ok_or_else(|| DBusError("no stream".into()))?;
+    let raw = fd.as_raw_fd();
+    eprintln!("[portal] pipewire fd = {raw}, node = {node}");
+    // Clear FD_CLOEXEC so the worker subprocesses inherit this fd across exec.
+    unsafe {
+        libc::fcntl(raw, libc::F_SETFD, 0);
+    }
+    let exe = std::env::current_exe()?;
+
+    let mut results = Vec::new();
+    for cell in all_cells().into_iter().filter(cell_enabled) {
+        // Path A negotiates freely (format-agnostic), so its 4 modifier cells are
+        // identical — run it only once.
+        if cell.path == ImportPath::DirectVa && cell.modifier.name != "LINEAR" {
+            continue;
+        }
+        let id = cell_label(&cell);
+        let hdr = if cell.path == ImportPath::DirectVa {
+            "A/direct-va/(free-negotiate)".to_string()
+        } else {
+            id.clone()
+        };
+        eprintln!("=== {hdr} ===");
+        let r = spawn_cell(&exe, raw, node, &id);
+        eprintln!(
+            "  ok={} first_bytes={} first_latency={:.1}ms avg={:.2}ms\n  reason={}\n  caps={}",
+            r.ok, r.first_frame_bytes, r.first_latency_ms, r.avg_ms, r.reason, r.negotiated
+        );
+        results.push(r);
+    }
+    print_summary(&results);
+    Ok(())
+}
+
+fn print_summary(results: &[CellResult]) {
+    println!("\n================ SUMMARY ================");
+    println!(
+        "{:<30} {:>3} {:>12} {:>10} {:>9}  {}",
+        "cell", "ok", "first_bytes", "first_ms", "avg_ms", "note/reason"
+    );
+    for r in results {
+        println!(
+            "{:<30} {:>3} {:>12} {:>10.1} {:>9.2}  {}",
+            r.label,
+            if r.ok { "Y" } else { "n" },
+            r.first_frame_bytes,
+            r.first_latency_ms,
+            r.avg_ms,
+            if r.reason.is_empty() { "-" } else { &r.reason }
+        );
+    }
+}
+
+/// Coordinator side: run one cell in a fresh worker subprocess and collect its
+/// RESULT. A worker that dies (segfault/abort) yields a `worker crashed` result
+/// rather than aborting the whole matrix.
+fn spawn_cell(exe: &std::path::Path, fd: i32, node: u64, id: &str) -> CellResult {
+    match Command::new(exe)
+        .env("PROBE_RUN_ONE", id)
+        .env("PROBE_FD", fd.to_string())
+        .env("PROBE_NODE", node.to_string())
+        .stderr(Stdio::null())
+        .output()
+    {
+        Ok(o) => parse_result(&o.stdout).unwrap_or_else(|| CellResult {
+            label: id.to_string(),
+            reason: format!("worker crashed/died ({}) — GL/VA crash, not a verdict", o.status),
+            ..Default::default()
+        }),
+        Err(e) => CellResult {
+            label: id.to_string(),
+            reason: format!("spawn failed: {e}"),
+            ..Default::default()
+        },
+    }
+}
+
+/// Worker side: build + run exactly one cell, print a tab-separated RESULT line.
+fn run_worker(id: &str) -> Result<(), Box<dyn Error>> {
+    gst::init()?;
+    assert_eq!(unsafe { vaapi_probe_selftest() }, 42);
+    let fd: i32 = std::env::var("PROBE_FD")?
+        .parse()
+        .map_err(|_| DBusError("bad PROBE_FD".into()))?;
+    let node: u64 = std::env::var("PROBE_NODE")?
+        .parse()
+        .map_err(|_| DBusError("bad PROBE_NODE".into()))?;
+    let cell = parse_cell(id).ok_or_else(|| DBusError(format!("bad cell id {id}")))?;
+    let r = if cell.path == ImportPath::FfmpegImport {
+        run_ffmpeg_cell(fd, node, &cell)
+    } else {
+        run_gst_cell(fd, node, &cell)
+    };
+    println!(
+        "RESULT\t{}\t{}\t{}\t{:.3}\t{:.3}\t{}\t{}",
+        r.label,
+        r.ok as u8,
+        r.first_frame_bytes,
+        r.first_latency_ms,
+        r.avg_ms,
+        san(&r.reason),
+        san(&r.negotiated)
+    );
+    Ok(())
+}
+
+fn parse_cell(label: &str) -> Option<Cell> {
+    let (path_str, mod_name) = label.rsplit_once('/')?;
+    let path = PATHS.into_iter().find(|p| p.short() == path_str)?;
+    let modifier = MODIFIERS.into_iter().find(|m| m.name == mod_name)?;
+    Some(Cell { path, modifier })
+}
+
+fn parse_result(out: &[u8]) -> Option<CellResult> {
+    let s = String::from_utf8_lossy(out);
+    for line in s.lines() {
+        if let Some(rest) = line.strip_prefix("RESULT\t") {
+            let f: Vec<&str> = rest.split('\t').collect();
+            if f.len() >= 7 {
+                return Some(CellResult {
+                    label: f[0].to_string(),
+                    ok: f[1] == "1",
+                    first_frame_bytes: f[2].parse().unwrap_or(0),
+                    first_latency_ms: f[3].parse().unwrap_or(0.0),
+                    avg_ms: f[4].parse().unwrap_or(0.0),
+                    reason: f[5].to_string(),
+                    negotiated: f[6].to_string(),
+                });
+            }
+        }
+    }
+    None
+}
+
+fn san(s: &str) -> String {
+    s.replace(['\t', '\n', '\r'], " ")
+}
+
+fn dmabuf_appsink() -> Result<AppSink, Box<dyn Error>> {
+    let s = mk("appsink")?;
+    s.set_property("drop", &true);
+    s.set_property("max-buffers", &1u32);
+    let a = s
+        .dynamic_cast::<AppSink>()
+        .map_err(|_| DBusError("not appsink".into()))?;
+    // Keep the buffer as a DMA_DRM dmabuf — do NOT download to system memory.
+    a.set_caps(Some(
+        &"video/x-raw(memory:DMABuf), format=(string)DMA_DRM".parse::<gst::Caps>()?,
+    ));
+    Ok(a)
+}
+
+/// Path C: pull a DMA_DRM dmabuf from `pipewiresrc`, extract fd/stride/offset, and
+/// hand it to `lib/vaapi_import_probe.c` which imports it into VAAPI via
+/// `hwmap=derive_device=vaapi` and encodes one `h264_vaapi` frame.
+fn run_ffmpeg_cell(fd: i32, node: u64, cell: &Cell) -> CellResult {
+    let label = cell_label(cell);
+    let mut r = CellResult {
+        label: label.clone(),
+        ..Default::default()
+    };
+
+    let pipeline = gst::Pipeline::new();
+    let build = (|| -> Result<AppSink, Box<dyn Error>> {
+        let src = mk("pipewiresrc")?;
+        src.set_property("fd", &fd);
+        src.set_property("path", &format!("{node}"));
+        src.set_property("always-copy", &false);
+        let capsfilter = mk("capsfilter")?;
+        capsfilter.set_property(
+            "caps",
+            &xr24_caps(&[&drm_fourcc_mod_string(&cell.modifier)]).parse::<gst::Caps>()?,
+        );
+        let sink = dmabuf_appsink()?;
+        let sink_el = sink.clone().upcast::<gst::Element>();
+        pipeline.add_many([&src, &capsfilter, &sink_el])?;
+        src.link(&capsfilter)?;
+        capsfilter.link(&sink_el)?;
+        Ok(sink)
+    })();
+    let appsink = match build {
+        Ok(a) => a,
+        Err(e) => {
+            r.reason = format!("build: {e}");
+            return r;
+        }
+    };
+
+    if pipeline.set_state(gst::State::Playing).is_err() {
+        r.reason = format!("set_state(Playing) failed: {}", drain_bus(&pipeline));
+        let _ = pipeline.set_state(gst::State::Null);
+        return r;
+    }
+    let _ = pipeline.state(gst::ClockTime::from_seconds(5));
+
+    let sample = match appsink.try_pull_sample(gst::ClockTime::from_seconds(5)) {
+        Some(s) => s,
+        None => {
+            r.reason = format!("no dmabuf frame in 5s: {}", drain_bus(&pipeline));
+            let _ = pipeline.set_state(gst::State::Null);
+            return r;
+        }
+    };
+    r.negotiated = sample.caps().map(|c| c.to_string()).unwrap_or_default();
+
+    let buffer = match sample.buffer() {
+        Some(b) => b,
+        None => {
+            r.reason = "sample has no buffer".into();
+            let _ = pipeline.set_state(gst::State::Null);
+            return r;
+        }
+    };
+    let st = sample.caps().unwrap().structure(0).unwrap().to_owned();
+    let w = st.get::<i32>("width").unwrap_or(0) as u32;
+    let h = st.get::<i32>("height").unwrap_or(0) as u32;
+    let vmeta = buffer.meta::<VideoMeta>();
+    let stride = vmeta
+        .as_ref()
+        .map(|m| m.stride()[0])
+        .unwrap_or((w as i32) * 4) as u32;
+    let offset = vmeta.as_ref().map(|m| m.offset()[0]).unwrap_or(0) as u32;
+    let dfd = buffer
+        .peek_memory(0)
+        .downcast_memory_ref::<gstreamer_allocators::DmaBufMemory>()
+        .map(|m| m.fd());
+    let dfd = match dfd {
+        Some(x) => x,
+        None => {
+            r.reason = "buffer memory is not a DmaBufMemory".into();
+            let _ = pipeline.set_state(gst::State::Null);
+            return r;
+        }
+    };
+
+    let mut reason = vec![0u8; 256];
+    let t0 = Instant::now();
+    let bytes = unsafe {
+        vaapi_probe_encode_dmabuf(
+            dfd,
+            w,
+            h,
+            xr24_fourcc(),
+            cell.modifier.drm,
+            stride,
+            offset,
+            reason.as_mut_ptr(),
+            reason.len() as c_int,
+        )
+    };
+    r.first_latency_ms = t0.elapsed().as_secs_f64() * 1000.0;
+
+    if bytes >= 0 {
+        r.ok = true;
+        r.first_frame_bytes = bytes as usize;
+    } else {
+        let end = reason.iter().position(|&b| b == 0).unwrap_or(reason.len());
+        r.reason = String::from_utf8_lossy(&reason[..end]).into_owned();
+    }
+
+    let _ = pipeline.set_state(gst::State::Null);
+    std::thread::sleep(Duration::from_millis(300));
+    r
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matrix_has_16_cells_in_path_major_order() {
+        let cells = all_cells();
+        assert_eq!(cells.len(), 16);
+        assert_eq!(cells[0].path, ImportPath::DirectVa);
+        assert_eq!(cells[0].modifier.name, "LINEAR");
+        assert_eq!(cells[3].modifier.name, "Y_TILED_CCS");
+        assert_eq!(cells[4].path, ImportPath::GlToVa);
+    }
+
+    #[test]
+    fn linear_uses_bare_fourcc_others_carry_modifier() {
+        assert_eq!(drm_fourcc_mod_string(&MODIFIERS[0]), "XR24"); // LINEAR
+        assert_eq!(
+            drm_fourcc_mod_string(&MODIFIERS[3]),
+            "XR24:0x0100000000000008" // Y_TILED_CCS
+        );
+    }
+
+    #[test]
+    fn caps_builder_emits_dmabuf_drm_list() {
+        let caps = xr24_caps(&["XR24", "XR24:0x0100000000000002"]);
+        assert!(caps.contains("memory:DMABuf"));
+        assert!(caps.contains("DMA_DRM"));
+        assert!(caps.contains("drm-format=(list){"));
+        assert!(caps.contains("XR24:0x0100000000000002"));
+    }
+
+    #[test]
+    fn probe_only_filter_matches_label_substring() {
+        let cell = Cell {
+            path: ImportPath::FfmpegImport,
+            modifier: MODIFIERS[3],
+        };
+        assert!(cell_label(&cell).contains("Y_TILED_CCS"));
+        assert!(cell_label(&cell).contains("ffmpeg"));
+    }
+}

--- a/examples/vaapi_probe.rs
+++ b/examples/vaapi_probe.rs
@@ -1,0 +1,56 @@
+// Minimal VAAPI encoder probe — no portal, no browser, no capture.
+// Just creates a VideoEncoder with try_vaapi=true, feeds synthetic
+// BGR0 frames, and lets the ffmpeg log tell us which encoder was selected.
+//
+// Run:
+//   cargo run --example vaapi_probe 2>&1 | grep -E '(Video:|ERROR|WARN|Scale filter|VAAPI|hwupload|vaapi)'
+
+// Pull in the needed modules the same way pw_probe.rs does.
+#[path = "../src/cerror.rs"]
+mod cerror;
+#[path = "../src/log.rs"]
+mod log;
+#[path = "../src/video.rs"]
+mod video;
+
+use std::sync::mpsc;
+
+fn main() {
+    let (tx, _rx) = mpsc::sync_channel::<String>(32);
+    log::setup_logging(tx);
+
+    const WIDTH: usize = 1920;
+    const HEIGHT: usize = 1080;
+
+    let mut buf = vec![0u8; WIDTH * HEIGHT * 4];
+    for j in 0..(WIDTH * HEIGHT) {
+        let off = j * 4;
+        buf[off] = ((j * 3) % 256) as u8;
+        buf[off + 1] = ((j * 5) % 256) as u8;
+        buf[off + 2] = ((j * 7) % 256) as u8;
+        buf[off + 3] = 0;
+    }
+
+    let opts = video::EncoderOptions {
+        try_vaapi: true,
+        try_nvenc: false,
+        try_videotoolbox: false,
+        try_mediafoundation: false,
+        input_is_dmabuf: false,
+    };
+
+    let mut encoder = match video::VideoEncoder::new(WIDTH, HEIGHT, WIDTH, HEIGHT, |_| {}, opts) {
+        Ok(enc) => enc,
+        Err(e) => {
+            eprintln!("FAILED to create VideoEncoder: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    // Encode a few frames to exercise the pipeline.
+    for _ in 0..5 {
+        encoder.encode(video::PixelProvider::BGR0(WIDTH, HEIGHT, &buf));
+    }
+
+    eprintln!("\n--- vaapi_probe: done ---");
+}

--- a/lib/encode_video.c
+++ b/lib/encode_video.c
@@ -22,6 +22,9 @@
 #include "log.h"
 
 #ifdef HAS_VAAPI
+#include <unistd.h>
+
+#include <libavutil/hwcontext_drm.h>
 #include <libavutil/hwcontext_vaapi.h>
 #include <va/va.h>
 #endif
@@ -73,6 +76,15 @@ typedef struct VideoContext
 	int try_nvenc;
 	int try_videotoolbox;
 	int try_mediafoundation;
+
+	// Zero-copy dmabuf input (VAAPI only).
+	int input_dmabuf;            // 1 when frames arrive as DRM-PRIME dmabufs
+	AVBufferRef* drm_device_ctx; // DRM device for wrapping the incoming fd
+	AVBufferRef* drm_frames_ctx; // DRM_PRIME frames pool (format descriptor)
+	AVFilterGraph* dmabuf_graph;
+	AVFilterContext* dmabuf_src;  // buffersrc (DRM_PRIME)
+	AVFilterContext* dmabuf_sink; // buffersink (VAAPI NV12)
+	AVFrame* dmabuf_out;          // reused output frame
 } VideoContext;
 
 // this is a rust function and lives in src/video.rs
@@ -130,6 +142,23 @@ void log_callback(void* _ptr, int level, const char* fmt_orig, va_list args)
 
 // called in src/log.rs
 void init_ffmpeg_logger() { av_log_set_callback(log_callback); }
+
+// Startup probe: 1 if a VAAPI device opens AND the h264_vaapi encoder exists,
+// else 0. Gates the zero-copy dmabuf path so it never has to serve a software
+// encoder. Called from src/video.rs.
+int vaapi_encoder_available(void)
+{
+#ifdef HAS_VAAPI
+	const char* dev = getenv("WEYLUS_VAAPI_DEVICE");
+	AVBufferRef* d = NULL;
+	if (av_hwdevice_ctx_create(&d, AV_HWDEVICE_TYPE_VAAPI, dev, NULL, 0) != 0)
+		return 0;
+	av_buffer_unref(&d);
+	return avcodec_find_encoder_by_name("h264_vaapi") ? 1 : 0;
+#else
+	return 0;
+#endif
+}
 
 void set_codec_params(VideoContext* ctx)
 {
@@ -534,6 +563,105 @@ void scale_frame(ScaleContext* ctx, Error* err)
 	}
 }
 
+#ifdef HAS_VAAPI
+// Build the zero-copy import graph:
+//   buffer(DRM_PRIME) -> hwmap=derive_device=vaapi -> scale_vaapi=nv12 -> buffersink
+// Proven end-to-end in lib/vaapi_import_probe.c on branch debug/vaapi-zerocopy-probe.
+// The graph is configured once here; fill_dmabuf() pushes each frame through it.
+static int build_dmabuf_graph(VideoContext* ctx)
+{
+	int ret;
+	// ffmpeg's DRM backend does open(device), so device MUST be a real node path
+	// (passing NULL yields open(NULL) -> EFAULT).
+	const char* drm_node = getenv("WEYLUS_VAAPI_DRM_NODE");
+	if (!drm_node || !drm_node[0])
+		drm_node = "/dev/dri/renderD128";
+	if ((ret = av_hwdevice_ctx_create(
+			 &ctx->drm_device_ctx, AV_HWDEVICE_TYPE_DRM, drm_node, NULL, 0)) < 0)
+		return ret;
+
+	ctx->drm_frames_ctx = av_hwframe_ctx_alloc(ctx->drm_device_ctx);
+	if (!ctx->drm_frames_ctx)
+		return AVERROR(ENOMEM);
+	AVHWFramesContext* fc = (AVHWFramesContext*)ctx->drm_frames_ctx->data;
+	fc->format = AV_PIX_FMT_DRM_PRIME;
+	fc->sw_format = AV_PIX_FMT_BGR0; // XR24 == XRGB8888 little-endian == BGR0
+	fc->width = ctx->width_in;
+	fc->height = ctx->height_in;
+	if ((ret = av_hwframe_ctx_init(ctx->drm_frames_ctx)) < 0)
+		return ret;
+
+	ctx->dmabuf_graph = avfilter_graph_alloc();
+	if (!ctx->dmabuf_graph)
+		return AVERROR(ENOMEM);
+
+	// A hardware pix_fmt cannot be passed via the args string; alloc the filter,
+	// set parameters (incl. hw_frames_ctx), then init with NULL.
+	ctx->dmabuf_src =
+		avfilter_graph_alloc_filter(ctx->dmabuf_graph, avfilter_get_by_name("buffer"), "in");
+	if (!ctx->dmabuf_src)
+		return AVERROR(ENOMEM);
+	AVBufferSrcParameters* p = av_buffersrc_parameters_alloc();
+	p->format = AV_PIX_FMT_DRM_PRIME;
+	p->width = ctx->width_in;
+	p->height = ctx->height_in;
+	p->time_base = TIME_BASE;
+	p->frame_rate = (AVRational){30, 1};
+	p->hw_frames_ctx = av_buffer_ref(ctx->drm_frames_ctx);
+	ret = av_buffersrc_parameters_set(ctx->dmabuf_src, p);
+	av_free(p);
+	if (ret < 0)
+		return ret;
+	if ((ret = avfilter_init_str(ctx->dmabuf_src, NULL)) < 0)
+		return ret;
+
+	AVFilterContext* map_ctx;
+	if ((ret = avfilter_graph_create_filter(
+			 &map_ctx,
+			 avfilter_get_by_name("hwmap"),
+			 "map",
+			 "derive_device=vaapi:mode=read",
+			 NULL,
+			 ctx->dmabuf_graph)) < 0)
+		return ret;
+
+	// scale_vaapi also clamps to the VAAPI H.264 4096x4096 limit via width_out/height_out.
+	char scale_args[128];
+	snprintf(
+		scale_args, sizeof(scale_args), "w=%d:h=%d:format=nv12", ctx->width_out, ctx->height_out);
+	AVFilterContext* scale_ctx;
+	if ((ret = avfilter_graph_create_filter(
+			 &scale_ctx,
+			 avfilter_get_by_name("scale_vaapi"),
+			 "scale",
+			 scale_args,
+			 NULL,
+			 ctx->dmabuf_graph)) < 0)
+		return ret;
+
+	ctx->dmabuf_sink =
+		avfilter_graph_alloc_filter(ctx->dmabuf_graph, avfilter_get_by_name("buffersink"), "out");
+	if (!ctx->dmabuf_sink)
+		return AVERROR(ENOMEM);
+	if ((ret = avfilter_init_str(ctx->dmabuf_sink, NULL)) < 0)
+		return ret;
+
+	if ((ret = avfilter_link(ctx->dmabuf_src, 0, map_ctx, 0)) < 0)
+		return ret;
+	if ((ret = avfilter_link(map_ctx, 0, scale_ctx, 0)) < 0)
+		return ret;
+	if ((ret = avfilter_link(scale_ctx, 0, ctx->dmabuf_sink, 0)) < 0)
+		return ret;
+	if ((ret = avfilter_graph_config(ctx->dmabuf_graph, NULL)) < 0)
+		return ret;
+
+	ctx->dmabuf_out = av_frame_alloc();
+	if (!ctx->dmabuf_out)
+		return AVERROR(ENOMEM);
+	return 0;
+}
+#endif
+
 void open_video(VideoContext* ctx, Error* err)
 {
 	if (ctx->width_out <= 1 || ctx->height_out <= 1)
@@ -556,9 +684,36 @@ void open_video(VideoContext* ctx, Error* err)
 	int using_hw = 0;
 
 #ifdef HAS_VAAPI
+	// Zero-copy path: frames arrive as DRM-PRIME dmabufs. Import them straight into
+	// VAAPI (hwmap) and open h264_vaapi from the graph's sink hw_frames_ctx — no
+	// GPU->CPU->GPU round trip, no init_scalers.
+	if (ctx->try_vaapi && ctx->input_dmabuf)
+	{
+		ret = build_dmabuf_graph(ctx);
+		if (ret < 0)
+			ERROR(err, 1, "dmabuf VAAPI graph setup failed: %s", av_err2str(ret));
+		AVBufferRef* enc_frames = av_buffersink_get_hw_frames_ctx(ctx->dmabuf_sink);
+		if (!enc_frames)
+			ERROR(err, 1, "dmabuf graph produced no hw_frames_ctx");
+		codec = avcodec_find_encoder_by_name("h264_vaapi");
+		if (!codec)
+			ERROR(err, 1, "no h264_vaapi encoder");
+		ctx->c = avcodec_alloc_context3(codec);
+		if (!ctx->c)
+			ERROR(err, 1, "Could not allocate h264_vaapi context");
+		ctx->c->pix_fmt = AV_PIX_FMT_VAAPI;
+		ctx->c->hw_frames_ctx = av_buffer_ref(enc_frames);
+		av_opt_set(ctx->c->priv_data, "quality", "7", 0);
+		av_opt_set(ctx->c->priv_data, "qp", "23", 0);
+		set_codec_params(ctx);
+		if ((ret = avcodec_open2(ctx->c, codec, NULL)) < 0)
+			ERROR(err, 1, "open h264_vaapi (dmabuf): %s", av_err2str(ret));
+		using_hw = 1;
+	}
+
 	char* vaapi_device = getenv("WEYLUS_VAAPI_DEVICE");
 
-	if (ctx->try_vaapi &&
+	if (ctx->try_vaapi && !ctx->input_dmabuf && !using_hw &&
 		av_hwdevice_ctx_create(
 			&ctx->hw_device_ctx, AV_HWDEVICE_TYPE_VAAPI, vaapi_device, NULL, 0) == 0)
 	{
@@ -889,6 +1044,14 @@ void destroy_video_encoder(VideoContext* ctx)
 	}
 	if (ctx->hw_device_ctx)
 		av_buffer_unref(&ctx->hw_device_ctx);
+	if (ctx->dmabuf_out)
+		av_frame_free(&ctx->dmabuf_out);
+	if (ctx->dmabuf_graph)
+		avfilter_graph_free(&ctx->dmabuf_graph);
+	if (ctx->drm_frames_ctx)
+		av_buffer_unref(&ctx->drm_frames_ctx);
+	if (ctx->drm_device_ctx)
+		av_buffer_unref(&ctx->drm_device_ctx);
 	free(ctx);
 }
 
@@ -933,7 +1096,8 @@ VideoContext* init_video_encoder(
 	int try_vaapi,
 	int try_nvenc,
 	int try_videotoolbox,
-	int try_mediafoundation)
+	int try_mediafoundation,
+	int input_dmabuf)
 {
 	VideoContext* ctx = malloc(sizeof(VideoContext));
 	ctx->rust_ctx = rust_ctx;
@@ -949,6 +1113,13 @@ VideoContext* init_video_encoder(
 	ctx->try_videotoolbox = try_videotoolbox;
 	ctx->try_mediafoundation = try_mediafoundation;
 	ctx->hw_device_ctx = NULL;
+	ctx->input_dmabuf = input_dmabuf;
+	ctx->drm_device_ctx = NULL;
+	ctx->drm_frames_ctx = NULL;
+	ctx->dmabuf_graph = NULL;
+	ctx->dmabuf_src = NULL;
+	ctx->dmabuf_sink = NULL;
+	ctx->dmabuf_out = NULL;
 
 	// make sure all scalers are zero initialized so that destroy can always be called
 	memset(&ctx->scalers, 0, sizeof(Scalers));
@@ -991,3 +1162,71 @@ void fill_rgb0(VideoContext* ctx, const void* data, Error* err)
 	OK_OR_ABORT(err)
 	ctx->frame = scaler->frame_out;
 }
+
+// Zero-copy input: wrap the incoming dmabuf fd as a single-plane DRM-PRIME frame,
+// push it through the import graph, and hand the mapped VAAPI NV12 frame to the
+// encoder via ctx->frame. Adapted from lib/vaapi_import_probe.c.
+#ifdef HAS_VAAPI
+// AVBufferRef free callback: frees the AVDRMFrameDescriptor backing the frame.
+// A dedicated wrapper (rather than casting av_free) keeps the signature exact
+// and avoids -Wcast-function-type.
+static void free_drm_descriptor(void* opaque, uint8_t* data)
+{
+	(void)opaque;
+	av_free(data);
+}
+
+void fill_dmabuf(VideoContext* ctx, int fd, unsigned int fourcc,
+	unsigned long long modifier, unsigned int stride, unsigned int offset, Error* err)
+{
+	ctx->frame = NULL;
+	// True dmabuf size: the compositor may report a bogus GstMemory size, so measure the fd.
+	off_t sz = lseek(fd, 0, SEEK_END);
+	if (sz <= 0)
+		sz = (off_t)stride * ctx->height_in;
+
+	AVFrame* drm = av_frame_alloc();
+	if (!drm)
+		ERROR(err, 1, "dmabuf: av_frame_alloc failed");
+	drm->format = AV_PIX_FMT_DRM_PRIME;
+	drm->width = ctx->width_in;
+	drm->height = ctx->height_in;
+	AVDRMFrameDescriptor* d = av_mallocz(sizeof(*d));
+	d->nb_objects = 1;
+	d->objects[0].fd = fd;
+	d->objects[0].size = sz;
+	d->objects[0].format_modifier = modifier;
+	d->nb_layers = 1;
+	d->layers[0].format = fourcc;
+	d->layers[0].nb_planes = 1;
+	d->layers[0].planes[0].object_index = 0;
+	d->layers[0].planes[0].offset = offset;
+	d->layers[0].planes[0].pitch = stride;
+	drm->data[0] = (uint8_t*)d;
+	drm->buf[0] = av_buffer_create((uint8_t*)d, sizeof(*d), free_drm_descriptor, NULL, 0);
+	drm->hw_frames_ctx = av_buffer_ref(ctx->drm_frames_ctx);
+
+	int ret = av_buffersrc_add_frame(ctx->dmabuf_src, drm);
+	av_frame_free(&drm);
+	if (ret < 0)
+		ERROR(err, 1, "dmabuf buffersrc_add_frame: %s", av_err2str(ret));
+
+	av_frame_unref(ctx->dmabuf_out);
+	ret = av_buffersink_get_frame(ctx->dmabuf_sink, ctx->dmabuf_out);
+	if (ret < 0)
+		ERROR(err, 1, "dmabuf buffersink_get_frame: %s", av_err2str(ret));
+	ctx->frame = ctx->dmabuf_out;
+}
+#else
+void fill_dmabuf(VideoContext* ctx, int fd, unsigned int fourcc,
+	unsigned long long modifier, unsigned int stride, unsigned int offset, Error* err)
+{
+	(void)ctx;
+	(void)fd;
+	(void)fourcc;
+	(void)modifier;
+	(void)stride;
+	(void)offset;
+	ERROR(err, 1, "dmabuf capture requires a VAAPI-enabled build");
+}
+#endif

--- a/lib/encode_video.c
+++ b/lib/encode_video.c
@@ -265,6 +265,9 @@ void init_scaler(
 	inputs->pad_idx = 0;
 	inputs->next = NULL;
 
+	int hwupload_created = 0;
+	AVFilterContext* hwupload_ctx = NULL;
+
 	switch (pix_fmt_out)
 	{
 	case AV_PIX_FMT_CUDA:
@@ -293,22 +296,61 @@ void init_scaler(
 		}
 		break;
 	case AV_PIX_FMT_VAAPI:
+	{
+		// Create hwupload filter manually so hw_device_ctx is set
+		// before the filter's init() is called.
+		const AVFilter* hwupload_filter = avfilter_get_by_name("hwupload");
+		if (!hwupload_filter)
+		{
+			ret = AVERROR(ENOSYS);
+			log_warn("hwupload filter not found");
+			goto end;
+		}
+		hwupload_ctx = avfilter_graph_alloc_filter(
+			ctx->filter_graph_scale, hwupload_filter, "hwupload");
+		if (!hwupload_ctx)
+		{
+			ret = AVERROR(ENOMEM);
+			log_warn("Cannot allocate hwupload filter");
+			goto end;
+		}
+		hwupload_ctx->hw_device_ctx = av_buffer_ref(hw_device_ctx);
+		ret = avfilter_init_dict(hwupload_ctx, NULL);
+		if (ret < 0)
+		{
+			log_warn("Cannot init hwupload filter: %s", av_err2str(ret));
+			goto end;
+		}
+		hwupload_created = 1;
+
 		if (pix_fmt_in == AV_PIX_FMT_RGB24)
+		{
+			// Chain: buffersrc -> scale -> hwupload -> buffersink
+			// Parsed "scale" connects to hwupload; we link
+			// hwupload -> buffersink manually below.
+			inputs->filter_ctx = hwupload_ctx;
 			snprintf(
 				args,
 				sizeof(args),
-				"scale=w=%d:h=%d:flags=fast_bilinear,hwupload",
+				"scale=w=%d:h=%d:flags=fast_bilinear",
 				width_out,
 				height_out);
+		}
 		else
+		{
+			// Chain: buffersrc -> hwupload -> scale_vaapi -> buffersink
+			// buffersrc -> hwupload is linked manually below.
+			outputs->filter_ctx = hwupload_ctx;
 			snprintf(
 				args,
 				sizeof(args),
-				"hwupload,scale_vaapi=w=%d:h=%d:format=%s:mode=fast",
+				"scale_vaapi=w=%d:h=%d:format=%s:mode=fast",
 				width_out,
 				height_out,
 				av_get_pix_fmt_name(pix_fmt_sw_out));
+		}
 		break;
+	}
 	default:
 		snprintf(args, sizeof(args), "scale=w=%d:h=%d:flags=fast_bilinear", width_out, height_out);
 	}
@@ -320,12 +362,30 @@ void init_scaler(
 		goto end;
 	}
 
-	for (unsigned int i = 0; i < ctx->filter_graph_scale->nb_filters; i++)
+	// For VAAPI with the hwupload filter created manually, complete the links.
+	if (hwupload_created)
 	{
-		AVFilterContext* filt = ctx->filter_graph_scale->filters[i];
-		if (strcmp(filt->filter->name, "hwupload") == 0)
+		if (pix_fmt_in == AV_PIX_FMT_RGB24)
 		{
-			filt->hw_device_ctx = av_buffer_ref(hw_device_ctx);
+			// buffersink receives from hwupload instead of directly
+			// from the parsed chain.
+			ret = avfilter_link(hwupload_ctx, 0, ctx->buffersink_scale_ctx, 0);
+			if (ret < 0)
+			{
+				log_warn("Cannot link hwupload to buffersink");
+				goto end;
+			}
+		}
+		else
+		{
+			// buffersrc feeds into hwupload.
+			ret = avfilter_link(
+				ctx->buffersrc_scale_ctx, 0, hwupload_ctx, 0);
+			if (ret < 0)
+			{
+				log_warn("Cannot link buffersrc to hwupload");
+				goto end;
+			}
 		}
 	}
 

--- a/lib/vaapi_import_probe.c
+++ b/lib/vaapi_import_probe.c
@@ -1,0 +1,288 @@
+#include "vaapi_import_probe.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <libavcodec/avcodec.h>
+#include <libavfilter/avfilter.h>
+#include <libavfilter/buffersink.h>
+#include <libavfilter/buffersrc.h>
+#include <libavutil/hwcontext.h>
+#include <libavutil/hwcontext_drm.h>
+#include <libavutil/pixdesc.h>
+
+int vaapi_probe_selftest(void) { return 42; }
+
+static void say(char* reason, int n, const char* what, int err)
+{
+	char e[128] = {0};
+	if (err)
+		av_strerror(err, e, sizeof(e));
+	snprintf(reason, n, "%s%s%s", what, err ? ": " : "", e);
+}
+
+int vaapi_probe_encode_dmabuf(
+	int dmabuf_fd,
+	unsigned int width,
+	unsigned int height,
+	unsigned int drm_fourcc,
+	unsigned long long drm_modifier,
+	unsigned int stride,
+	unsigned int offset,
+	char* reason,
+	int reason_len)
+{
+	int ret = -1;
+	int out_bytes = -1;
+	AVBufferRef* drm_dev = NULL;
+	AVBufferRef* drm_frames = NULL;
+	AVFrame* drm_frame = NULL;
+	AVFilterGraph* graph = NULL;
+	AVFilterContext* src_ctx = NULL;
+	AVFilterContext* map_ctx = NULL;
+	AVFilterContext* scale_ctx = NULL;
+	AVFilterContext* sink_ctx = NULL;
+	AVFrame* va_frame = av_frame_alloc();
+	AVCodecContext* enc = NULL;
+	AVPacket* pkt = av_packet_alloc();
+
+	// True dmabuf size: niri may report a bogus GstMemory size, so measure the fd.
+	off_t fd_size = lseek(dmabuf_fd, 0, SEEK_END);
+	if (fd_size <= 0)
+		fd_size = (off_t)stride * height;
+
+	// The VAAPI H.264 encoder maxes out at 4096x4096; downscale (preserving aspect,
+	// keeping even dims) so oversized monitors (e.g. 5120-wide) still encode. The
+	// dmabuf is still IMPORTED at native resolution — only the encode is clamped.
+	unsigned int out_w = width, out_h = height;
+	if (out_w > 4096)
+	{
+		out_h = (unsigned int)((unsigned long long)height * 4096u / width) & ~1u;
+		out_w = 4096;
+	}
+	if (out_h > 4096)
+	{
+		out_w = (unsigned int)((unsigned long long)out_w * 4096u / out_h) & ~1u;
+		out_h = 4096;
+	}
+
+	// 1) DRM device + a DRM_PRIME frames pool describing the incoming dmabuf.
+	// ffmpeg's DRM backend does open(device), so device MUST be a real node path
+	// (passing NULL yields open(NULL) -> EFAULT "Bad address").
+	const char* drm_node = getenv("WEYLUS_PROBE_DRM_NODE");
+	if (!drm_node || !drm_node[0])
+		drm_node = "/dev/dri/renderD128";
+	ret = av_hwdevice_ctx_create(&drm_dev, AV_HWDEVICE_TYPE_DRM, drm_node, NULL, 0);
+	if (ret < 0)
+	{
+		char what[128];
+		snprintf(what, sizeof(what), "hwdevice DRM create (%s)", drm_node);
+		say(reason, reason_len, what, ret);
+		goto done;
+	}
+
+	drm_frames = av_hwframe_ctx_alloc(drm_dev);
+	if (!drm_frames)
+	{
+		say(reason, reason_len, "hwframe_ctx_alloc", 0);
+		goto done;
+	}
+	{
+		AVHWFramesContext* fc = (AVHWFramesContext*)drm_frames->data;
+		fc->format = AV_PIX_FMT_DRM_PRIME;
+		fc->sw_format = AV_PIX_FMT_BGR0; // XR24 == XRGB8888 little-endian == BGR0
+		fc->width = width;
+		fc->height = height;
+		ret = av_hwframe_ctx_init(drm_frames);
+		if (ret < 0)
+		{
+			say(reason, reason_len, "drm hwframe_ctx_init", ret);
+			goto done;
+		}
+	}
+
+	// 2) Wrap the incoming fd as a single-plane AVDRMFrameDescriptor.
+	drm_frame = av_frame_alloc();
+	drm_frame->format = AV_PIX_FMT_DRM_PRIME;
+	drm_frame->width = width;
+	drm_frame->height = height;
+	{
+		AVDRMFrameDescriptor* d = av_mallocz(sizeof(*d));
+		d->nb_objects = 1;
+		d->objects[0].fd = dmabuf_fd;
+		d->objects[0].size = fd_size;
+		d->objects[0].format_modifier = drm_modifier;
+		d->nb_layers = 1;
+		d->layers[0].format = drm_fourcc;
+		d->layers[0].nb_planes = 1;
+		d->layers[0].planes[0].object_index = 0;
+		d->layers[0].planes[0].offset = offset;
+		d->layers[0].planes[0].pitch = stride;
+		drm_frame->data[0] = (uint8_t*)d;
+		drm_frame->buf[0] = av_buffer_create(
+			(uint8_t*)d, sizeof(*d), (void (*)(void*, uint8_t*))av_free, NULL, 0);
+		drm_frame->hw_frames_ctx = av_buffer_ref(drm_frames);
+	}
+
+	// 3) Filter graph:
+	//      buffer -> hwmap=derive_device=vaapi -> scale_vaapi=format=nv12 -> buffersink
+	graph = avfilter_graph_alloc();
+	{
+		// A hardware pix_fmt cannot be passed via the args string; alloc the
+		// filter, set parameters (incl. hw_frames_ctx), then init with NULL.
+		src_ctx = avfilter_graph_alloc_filter(graph, avfilter_get_by_name("buffer"), "in");
+		if (!src_ctx)
+		{
+			say(reason, reason_len, "alloc buffersrc", 0);
+			goto done;
+		}
+		AVBufferSrcParameters* p = av_buffersrc_parameters_alloc();
+		p->format = AV_PIX_FMT_DRM_PRIME;
+		p->width = width;
+		p->height = height;
+		p->time_base = (AVRational){1, 1000};
+		p->frame_rate = (AVRational){30, 1};
+		p->hw_frames_ctx = av_buffer_ref(drm_frames);
+		ret = av_buffersrc_parameters_set(src_ctx, p);
+		av_free(p);
+		if (ret < 0)
+		{
+			say(reason, reason_len, "buffersrc params", ret);
+			goto done;
+		}
+		ret = avfilter_init_str(src_ctx, NULL);
+		if (ret < 0)
+		{
+			say(reason, reason_len, "buffersrc init", ret);
+			goto done;
+		}
+
+		ret = avfilter_graph_create_filter(
+			&map_ctx,
+			avfilter_get_by_name("hwmap"),
+			"map",
+			"derive_device=vaapi:mode=read",
+			NULL,
+			graph);
+		if (ret < 0)
+		{
+			say(reason, reason_len, "create hwmap", ret);
+			goto done;
+		}
+
+		char scale_args[128];
+		snprintf(scale_args, sizeof(scale_args), "w=%u:h=%u:format=nv12", out_w, out_h);
+		ret = avfilter_graph_create_filter(
+			&scale_ctx,
+			avfilter_get_by_name("scale_vaapi"),
+			"scale",
+			scale_args,
+			NULL,
+			graph);
+		if (ret < 0)
+		{
+			say(reason, reason_len, "create scale_vaapi", ret);
+			goto done;
+		}
+
+		ret = avfilter_graph_create_filter(
+			&sink_ctx, avfilter_get_by_name("buffersink"), "out", NULL, NULL, graph);
+		if (ret < 0)
+		{
+			say(reason, reason_len, "create buffersink", ret);
+			goto done;
+		}
+
+		if ((ret = avfilter_link(src_ctx, 0, map_ctx, 0)) < 0
+			|| (ret = avfilter_link(map_ctx, 0, scale_ctx, 0)) < 0
+			|| (ret = avfilter_link(scale_ctx, 0, sink_ctx, 0)) < 0)
+		{
+			say(reason, reason_len, "filter link", ret);
+			goto done;
+		}
+		ret = avfilter_graph_config(graph, NULL);
+		if (ret < 0)
+		{
+			say(reason, reason_len, "graph config (VA import rejected?)", ret);
+			goto done;
+		}
+	}
+
+	// 4) Push the DRM frame, pull the mapped+scaled VAAPI NV12 frame.
+	ret = av_buffersrc_add_frame(src_ctx, drm_frame);
+	if (ret < 0)
+	{
+		say(reason, reason_len, "buffersrc_add_frame", ret);
+		goto done;
+	}
+	ret = av_buffersink_get_frame(sink_ctx, va_frame);
+	if (ret < 0)
+	{
+		say(reason, reason_len, "buffersink_get_frame (VA import/convert failed)", ret);
+		goto done;
+	}
+
+	// 5) h264_vaapi encoder using the mapped frame's hw_frames_ctx.
+	{
+		const AVCodec* codec = avcodec_find_encoder_by_name("h264_vaapi");
+		if (!codec)
+		{
+			say(reason, reason_len, "no h264_vaapi encoder", 0);
+			goto done;
+		}
+		enc = avcodec_alloc_context3(codec);
+		enc->width = out_w;
+		enc->height = out_h;
+		enc->time_base = (AVRational){1, 1000};
+		enc->framerate = (AVRational){30, 1};
+		enc->pix_fmt = AV_PIX_FMT_VAAPI;
+		enc->max_b_frames = 0;
+		if (!va_frame->hw_frames_ctx)
+		{
+			say(reason, reason_len, "mapped frame has no hw_frames_ctx", 0);
+			goto done;
+		}
+		enc->hw_frames_ctx = av_buffer_ref(va_frame->hw_frames_ctx);
+		ret = avcodec_open2(enc, codec, NULL);
+		if (ret < 0)
+		{
+			say(reason, reason_len, "avcodec_open2 h264_vaapi", ret);
+			goto done;
+		}
+		va_frame->pict_type = AV_PICTURE_TYPE_NONE;
+		ret = avcodec_send_frame(enc, va_frame);
+		if (ret < 0)
+		{
+			say(reason, reason_len, "send_frame", ret);
+			goto done;
+		}
+		avcodec_send_frame(enc, NULL); // flush
+		ret = avcodec_receive_packet(enc, pkt);
+		if (ret < 0)
+		{
+			say(reason, reason_len, "receive_packet", ret);
+			goto done;
+		}
+		out_bytes = pkt->size;
+		reason[0] = '\0';
+	}
+
+done:
+	if (pkt)
+		av_packet_free(&pkt);
+	if (enc)
+		avcodec_free_context(&enc);
+	if (va_frame)
+		av_frame_free(&va_frame);
+	if (graph)
+		avfilter_graph_free(&graph);
+	if (drm_frame)
+		av_frame_free(&drm_frame);
+	if (drm_frames)
+		av_buffer_unref(&drm_frames);
+	if (drm_dev)
+		av_buffer_unref(&drm_dev);
+	return out_bytes;
+}

--- a/lib/vaapi_import_probe.h
+++ b/lib/vaapi_import_probe.h
@@ -1,0 +1,24 @@
+#ifndef VAAPI_IMPORT_PROBE_H
+#define VAAPI_IMPORT_PROBE_H
+
+// Smoke test: returns 42. Confirms the probe C object is compiled and linked.
+int vaapi_probe_selftest(void);
+
+// Encode ONE H264 frame from a single-plane DRM-PRIME dmabuf, testing whether
+// VAAPI can import the buffer with zero CPU round-trip. The dmabuf is wrapped as
+// an AVDRMFrameDescriptor and pushed through:
+//   buffer(DRM_PRIME) -> hwmap=derive_device=vaapi -> scale_vaapi=nv12 -> h264_vaapi
+// Returns the encoded byte count on success, or a negative value on failure;
+// `reason` (capacity `reason_len`) receives a human-readable failure string.
+int vaapi_probe_encode_dmabuf(
+    int dmabuf_fd,
+    unsigned int width,
+    unsigned int height,
+    unsigned int drm_fourcc,
+    unsigned long long drm_modifier,
+    unsigned int stride,
+    unsigned int offset,
+    char* reason,
+    int reason_len);
+
+#endif

--- a/src/capturable/captrs_capture.rs
+++ b/src/capturable/captrs_capture.rs
@@ -32,7 +32,11 @@ impl Capturable for CaptrsCapturable {
     fn before_input(&mut self) -> Result<(), Box<dyn Error>> {
         Ok(())
     }
-    fn recorder(&self, _capture_cursor: bool) -> Result<Box<dyn Recorder>, Box<dyn Error>> {
+    fn recorder(
+        &self,
+        _capture_cursor: bool,
+        _prefer_dmabuf: bool,
+    ) -> Result<Box<dyn Recorder>, Box<dyn Error>> {
         Ok(Box::new(CaptrsRecorder::new(self.id)?))
     }
     fn geometry(&self) -> Result<Geometry, Box<dyn Error>> {

--- a/src/capturable/core_graphics.rs
+++ b/src/capturable/core_graphics.rs
@@ -65,7 +65,11 @@ impl Capturable for CGDisplayCapturable {
     fn before_input(&mut self) -> Result<(), Box<dyn Error>> {
         Ok(())
     }
-    fn recorder(&self, capture_cursor: bool) -> Result<Box<dyn Recorder>, Box<dyn Error>> {
+    fn recorder(
+        &self,
+        capture_cursor: bool,
+        _prefer_dmabuf: bool,
+    ) -> Result<Box<dyn Recorder>, Box<dyn Error>> {
         Ok(Box::new(RecorderCGDisplay::new(
             self.display,
             capture_cursor,
@@ -182,7 +186,11 @@ impl Capturable for CGWindowCapturable {
     fn before_input(&mut self) -> Result<(), Box<dyn Error>> {
         self.update_geometry()
     }
-    fn recorder(&self, capture_cursor: bool) -> Result<Box<dyn Recorder>, Box<dyn Error>> {
+    fn recorder(
+        &self,
+        capture_cursor: bool,
+        _prefer_dmabuf: bool,
+    ) -> Result<Box<dyn Recorder>, Box<dyn Error>> {
         Ok(Box::new(RecorderCGWindow {
             img_data: None,
             capture_cursor,

--- a/src/capturable/mod.rs
+++ b/src/capturable/mod.rs
@@ -9,6 +9,8 @@ pub mod pipewire;
 #[cfg(target_os = "linux")]
 #[allow(dead_code)]
 pub mod remote_desktop_dbus;
+#[cfg(target_os = "linux")]
+pub mod wayland_outputs;
 pub mod testsrc;
 
 #[cfg(target_os = "windows")]

--- a/src/capturable/mod.rs
+++ b/src/capturable/mod.rs
@@ -21,6 +21,13 @@ pub mod win_ctx;
 pub mod x11;
 pub trait Recorder {
     fn capture(&mut self) -> Result<crate::video::PixelProvider<'_>, Box<dyn Error>>;
+
+    /// True when `capture()` yields `PixelProvider::DmaBuf` (zero-copy VAAPI path).
+    /// The encoder must be put in dmabuf-input mode iff this is true. Defaults to
+    /// false for CPU-frame recorders.
+    fn is_dmabuf(&self) -> bool {
+        false
+    }
 }
 
 pub trait BoxCloneCapturable {
@@ -56,7 +63,15 @@ pub trait Capturable: Send + BoxCloneCapturable {
     fn before_input(&mut self) -> Result<(), Box<dyn Error>>;
 
     /// Return a Recorder that can record the current capturable.
-    fn recorder(&self, capture_cursor: bool) -> Result<Box<dyn Recorder>, Box<dyn Error>>;
+    ///
+    /// `prefer_dmabuf` asks the capturer to attempt a zero-copy dmabuf path when
+    /// available (only the PipeWire capturer acts on it); implementors that can
+    /// not are free to ignore it.
+    fn recorder(
+        &self,
+        capture_cursor: bool,
+        prefer_dmabuf: bool,
+    ) -> Result<Box<dyn Recorder>, Box<dyn Error>>;
 }
 
 impl Clone for Box<dyn Capturable> {

--- a/src/capturable/mod.rs
+++ b/src/capturable/mod.rs
@@ -66,13 +66,14 @@ impl Clone for Box<dyn Capturable> {
 pub fn get_capturables(
     #[cfg(target_os = "linux")] wayland_support: bool,
     #[cfg(target_os = "linux")] capture_cursor: bool,
+    #[cfg(target_os = "linux")] pipewire_pipeline: crate::config::PipewirePipeline,
 ) -> Vec<Box<dyn Capturable>> {
     let mut capturables: Vec<Box<dyn Capturable>> = vec![];
     #[cfg(target_os = "linux")]
     {
         if wayland_support {
             use crate::capturable::pipewire::get_capturables as get_capturables_pw;
-            match get_capturables_pw(capture_cursor) {
+            match get_capturables_pw(capture_cursor, pipewire_pipeline) {
                 Ok(captrs) => {
                     for c in captrs {
                         capturables.push(Box::new(c));

--- a/src/capturable/pipewire.rs
+++ b/src/capturable/pipewire.rs
@@ -29,6 +29,70 @@ use crate::capturable::remote_desktop_dbus::{
 struct PwStreamInfo {
     path: u64,
     source_type: u64,
+    /// Portal `position` (ii): the stream's (x, y) in the compositor's logical
+    /// coordinate space. Monitor streams only; `None` for windows / when absent.
+    position: Option<(i32, i32)>,
+    /// Portal `size` (ii): the stream's (width, height) in logical space.
+    size: Option<(i32, i32)>,
+}
+
+use crate::capturable::wayland_outputs::GlobalBox;
+
+/// Extract a D-Bus `(ii)` value (as the portal reports `position`/`size`) into `(i32, i32)`.
+///
+/// The value arrives wrapped in a Variant around a two-element struct, so we descend
+/// through any container layers and collect the integer leaves; a genuine `(ii)` yields
+/// exactly two.
+fn extract_ii(arg: &dyn RefArg) -> Option<(i32, i32)> {
+    fn collect_ints(arg: &dyn RefArg, out: &mut Vec<i64>) {
+        if let Some(i) = arg.as_i64() {
+            out.push(i);
+            return;
+        }
+        if let Some(it) = arg.as_iter() {
+            for x in it {
+                collect_ints(x, out);
+            }
+        }
+    }
+    let mut ints = Vec::new();
+    collect_ints(arg, &mut ints);
+    match ints.as_slice() {
+        [a, b] => Some((*a as i32, *b as i32)),
+        _ => None,
+    }
+}
+
+/// Compute the `Geometry::Relative` for a monitor stream whose logical rect is
+/// `(px, py, sw, sh)`, normalised against the global bounding box `gbox` (the space the
+/// compositor decodes tablet ABS axes against). Returns whole-screen `(0,0,1,1)` when the
+/// stream has no usable geometry (e.g. a window, which the portal reports as a dummy
+/// `1x1`) or when the global box is unknown/degenerate.
+fn relative_geometry(
+    source_type: u64,
+    position: Option<(i32, i32)>,
+    size: Option<(i32, i32)>,
+    gbox: Option<GlobalBox>,
+) -> Geometry {
+    // source_type 1 == MONITOR; windows (2) report bogus position/size.
+    if source_type != 1 {
+        return Geometry::Relative(0.0, 0.0, 1.0, 1.0);
+    }
+    match (position, size, gbox) {
+        (Some((px, py)), Some((sw, sh)), Some(g))
+            if g.width > 0 && g.height > 0 && sw > 1 && sh > 1 =>
+        {
+            let w = g.width as f64;
+            let h = g.height as f64;
+            Geometry::Relative(
+                (px - g.x) as f64 / w,
+                (py - g.y) as f64 / h,
+                sw as f64 / w,
+                sh as f64 / h,
+            )
+        }
+        _ => Geometry::Relative(0.0, 0.0, 1.0, 1.0),
+    }
 }
 
 #[derive(Debug)]
@@ -62,6 +126,14 @@ pub struct PipeWireCapturable {
     fd: OwnedFd,
     path: u64,
     source_type: u64,
+    /// Stream's logical (x, y) from the portal; used to map stylus input.
+    position: Option<(i32, i32)>,
+    /// Stream's logical (width, height) from the portal.
+    size: Option<(i32, i32)>,
+    /// Global bounding box of all outputs (logical space), queried once at
+    /// enumeration time. `None` when Wayland output geometry is unavailable, in
+    /// which case `geometry()` falls back to the whole screen.
+    global_box: Option<GlobalBox>,
     pipeline: PipewirePipeline,
 }
 
@@ -70,6 +142,7 @@ impl PipeWireCapturable {
         conn: Arc<SyncConnection>,
         fd: OwnedFd,
         stream: PwStreamInfo,
+        global_box: Option<GlobalBox>,
         pipeline: PipewirePipeline,
     ) -> Self {
         Self {
@@ -77,6 +150,9 @@ impl PipeWireCapturable {
             fd,
             path: stream.path,
             source_type: stream.source_type,
+            position: stream.position,
+            size: stream.size,
+            global_box,
             pipeline,
         }
     }
@@ -86,11 +162,15 @@ impl std::fmt::Debug for PipeWireCapturable {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "PipeWireCapturable {{dbus: {}, fd: {}, path: {}, source_type: {}, pipeline: {:?}}}",
+            "PipeWireCapturable {{dbus: {}, fd: {}, path: {}, source_type: {}, \
+             position: {:?}, size: {:?}, global_box: {:?}, pipeline: {:?}}}",
             self.dbus_conn.unique_name(),
             self.fd.as_raw_fd(),
             self.path,
             self.source_type,
+            self.position,
+            self.size,
+            self.global_box,
             self.pipeline,
         )
     }
@@ -107,7 +187,17 @@ impl Capturable for PipeWireCapturable {
     }
 
     fn geometry(&self) -> Result<Geometry, Box<dyn Error>> {
-        Ok(Geometry::Relative(0.0, 0.0, 1.0, 1.0))
+        let geometry =
+            relative_geometry(self.source_type, self.position, self.size, self.global_box);
+        // On Linux `Geometry` only has the `Relative` variant, so this destructure is
+        // irrefutable; it is purely to log the resolved mapping.
+        let Geometry::Relative(x, y, w, h) = geometry;
+        debug!(
+            "geometry() for path {} (source_type {}): stream position {:?} size {:?}, \
+             global_box {:?} -> Relative(x={:.4}, y={:.4}, w={:.4}, h={:.4})",
+            self.path, self.source_type, self.position, self.size, self.global_box, x, y, w, h
+        );
+        Ok(geometry)
     }
 
     fn before_input(&mut self) -> Result<(), Box<dyn Error>> {
@@ -554,6 +644,8 @@ fn streams_from_response(response: &OrgFreedesktopPortalRequestResponse) -> Vec<
                         source_type: attributes
                             .get("source_type")
                             .map_or(Some(0), |v| v.as_u64())?,
+                        position: attributes.get("position").and_then(|v| extract_ii(v)),
+                        size: attributes.get("size").and_then(|v| extract_ii(v)),
                     })
                 })
                 .collect::<Vec<PwStreamInfo>>(),
@@ -728,7 +820,19 @@ fn on_start_response(
 ) -> Result<(), Box<dyn Error>> {
     debug!("on_start_response");
     let mut context = context.lock().unwrap();
-    context.streams.append(&mut streams_from_response(&r));
+    let mut new_streams = streams_from_response(&r);
+    for s in &new_streams {
+        let kind = match s.source_type {
+            1 => "monitor",
+            2 => "window",
+            _ => "unknown",
+        };
+        debug!(
+            "Portal stream: node {}, source_type {} ({kind}), position {:?}, size {:?}",
+            s.path, s.source_type, s.position, s.size
+        );
+    }
+    context.streams.append(&mut new_streams);
     let session = context.session.clone();
     context
         .fd
@@ -813,8 +917,73 @@ pub fn get_capturables(
 ) -> Result<Vec<PipeWireCapturable>, Box<dyn Error>> {
     let (conn, fd, streams) = request_remote_desktop(capture_cursor)?;
     let conn = Arc::new(conn);
+    // Query the global output bounding box once so each capturable can map its
+    // portal-reported rect into the compositor's logical coordinate space. If this
+    // fails (no Wayland display / no xdg-output) geometry() falls back to whole-screen.
+    let global_box = crate::capturable::wayland_outputs::global_bounding_box();
+    debug!("Wayland global bounding box for stylus mapping: {global_box:?}");
     Ok(streams
         .into_iter()
-        .map(|s| PipeWireCapturable::new(conn.clone(), fd.clone(), s, pipeline))
+        .map(|s| PipeWireCapturable::new(conn.clone(), fd.clone(), s, global_box, pipeline))
         .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rel(g: &Geometry) -> (f64, f64, f64, f64) {
+        match g {
+            Geometry::Relative(x, y, w, h) => (*x, *y, *w, *h),
+            #[allow(unreachable_patterns)]
+            _ => panic!("expected Relative"),
+        }
+    }
+
+    const BOX_2688: GlobalBox = GlobalBox {
+        x: 0,
+        y: 0,
+        width: 4096,
+        height: 2688,
+    };
+
+    #[test]
+    fn monitor_maps_into_global_box() {
+        // eDP-1 as measured: logical (1328,1728) 1440x960 within the 4096x2688 box.
+        let g = relative_geometry(1, Some((1328, 1728)), Some((1440, 960)), Some(BOX_2688));
+        let (x, y, w, h) = rel(&g);
+        assert!((x - 1328.0 / 4096.0).abs() < 1e-9);
+        assert!((y - 1728.0 / 2688.0).abs() < 1e-9);
+        assert!((w - 1440.0 / 4096.0).abs() < 1e-9);
+        assert!((h - 960.0 / 2688.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn primary_monitor_maps_to_origin() {
+        // DP-1: logical (0,0) 4096x1728 -> covers full width, top portion.
+        let g = relative_geometry(1, Some((0, 0)), Some((4096, 1728)), Some(BOX_2688));
+        let (x, y, w, h) = rel(&g);
+        assert_eq!((x, y), (0.0, 0.0));
+        assert!((w - 1.0).abs() < 1e-9);
+        assert!((h - 1728.0 / 2688.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn window_falls_back_to_whole_screen() {
+        // source_type 2 == window; portal reports a dummy 1x1 we must ignore.
+        let g = relative_geometry(2, Some((0, 0)), Some((1, 1)), Some(BOX_2688));
+        assert_eq!(rel(&g), (0.0, 0.0, 1.0, 1.0));
+    }
+
+    #[test]
+    fn no_global_box_falls_back_to_whole_screen() {
+        let g = relative_geometry(1, Some((1328, 1728)), Some((1440, 960)), None);
+        assert_eq!(rel(&g), (0.0, 0.0, 1.0, 1.0));
+    }
+
+    #[test]
+    fn missing_position_falls_back_to_whole_screen() {
+        let g = relative_geometry(1, None, Some((1440, 960)), Some(BOX_2688));
+        assert_eq!(rel(&g), (0.0, 0.0, 1.0, 1.0));
+    }
 }

--- a/src/capturable/pipewire.rs
+++ b/src/capturable/pipewire.rs
@@ -199,8 +199,42 @@ impl Capturable for PipeWireCapturable {
         Ok(())
     }
 
-    fn recorder(&self, _capture_cursor: bool) -> Result<Box<dyn Recorder>, Box<dyn Error>> {
-        Ok(Box::new(PipeWireRecorder::new(self.clone())?))
+    fn recorder(
+        &self,
+        _capture_cursor: bool,
+        prefer_dmabuf: bool,
+    ) -> Result<Box<dyn Recorder>, Box<dyn Error>> {
+        Ok(Box::new(PipeWireRecorder::new(self.clone(), prefer_dmabuf)?))
+    }
+}
+
+// Non-CCS XR24 modifiers (LINEAR + X_TILED + Y_TILED), safe for both VA import
+// (zero-copy dmabuf path) and GL de-tile. Excludes niri's default CCS modifier
+// which is multi-plane and rejected by single-plane consumers.
+const XR24_NONCCS: &str = "video/x-raw(memory:DMABuf), format=(string)DMA_DRM, \
+     width=(int)[1,32767], height=(int)[1,32767], \
+     framerate=(fraction)[0/1,2147483647/1], drm-format=(list){ \
+     (string)XR24, (string)XR24:0x0100000000000001, (string)XR24:0x0100000000000002 }";
+// LINEAR only (bare fourcc = DRM_FORMAT_MOD_LINEAR), for the cheap-readback CPU
+// path: no de-tile needed on download.
+const XR24_LINEAR: &str = "video/x-raw(memory:DMABuf), format=(string)DMA_DRM, \
+     width=(int)[1,32767], height=(int)[1,32767], \
+     framerate=(fraction)[0/1,2147483647/1], drm-format=(string)XR24";
+
+/// Parse the DRM modifier out of a negotiated `drm-format` caps value, e.g.
+/// `"XR24:0x0100000000000002"` -> `0x0100000000000002` (Y_TILED). A bare fourcc
+/// (`"XR24"`) or an unparseable suffix means LINEAR (`0`). This MUST be threaded
+/// into the DRM-PRIME descriptor: if the buffer is tiled but we tell VAAPI it is
+/// linear, the import reads tiled memory as linear and the frame comes out
+/// spatially scrambled.
+fn parse_drm_modifier(drm_format: &str) -> u64 {
+    match drm_format.split_once(':') {
+        Some((_, m)) => {
+            let m = m.trim();
+            let hex = m.strip_prefix("0x").or_else(|| m.strip_prefix("0X")).unwrap_or(m);
+            u64::from_str_radix(hex, 16).unwrap_or(0)
+        }
+        None => 0,
     }
 }
 
@@ -213,10 +247,19 @@ pub struct PipeWireRecorder {
     appsink: AppSink,
     width: usize,
     height: usize,
+    // Zero-copy dmabuf path: when set, `capture()` returns `PixelProvider::DmaBuf`
+    // instead of a mapped CPU buffer.
+    is_dmabuf: bool,
+    // Retained backing buffer (holds the fd alive) + extracted DRM layout:
+    // (buffer, width, height, stride, offset, fd, modifier).
+    dmabuf: Option<(gst::Buffer, usize, usize, u32, u32, i32, u64)>,
 }
 
 impl PipeWireRecorder {
-    pub fn new(capturable: PipeWireCapturable) -> Result<Self, Box<dyn Error>> {
+    pub fn new(
+        capturable: PipeWireCapturable,
+        prefer_dmabuf: bool,
+    ) -> Result<Self, Box<dyn Error>> {
         // Two pipelines can turn a PipeWire screen-cast stream into the system-memory
         // `BGRx`/`RGBx` the appsink (and x264 encoder) need:
         //
@@ -244,6 +287,8 @@ impl PipeWireRecorder {
         {
             "direct" => PipewirePipeline::Direct,
             "gl" => PipewirePipeline::Gl,
+            "dmabuf" => PipewirePipeline::Dmabuf,
+            "linear-cpu" => PipewirePipeline::LinearCpu,
             "auto" => PipewirePipeline::Auto,
             _ => capturable.pipeline,
         };
@@ -251,18 +296,43 @@ impl PipeWireRecorder {
         match mode {
             PipewirePipeline::Direct => Self::start(Self::build_direct(&capturable)?),
             PipewirePipeline::Gl => Self::start(Self::build_gl(&capturable)?),
+            PipewirePipeline::Dmabuf => {
+                let mut r = Self::start(Self::build_dmabuf(&capturable)?)?;
+                r.is_dmabuf = true;
+                Ok(r)
+            }
+            PipewirePipeline::LinearCpu => Self::start(Self::build_linear_cpu(&capturable)?),
             PipewirePipeline::Auto => {
-                // probe the cheap direct path first.
+                // Probe the cheap direct path first (unchanged).
                 let (pipeline, appsink) = Self::build_direct(&capturable)?;
                 if Self::try_reach_playing(&pipeline, 3) {
                     return Ok(Self::finish(pipeline, appsink));
                 }
                 let _ = pipeline.set_state(gst::State::Null);
                 debug!(
-                    "Direct pipewiresrc path did not negotiate ({}); falling back to \
-                     GL DMA-BUF import.",
+                    "Direct pipewiresrc path did not negotiate ({}); trying the zero-copy \
+                     / GL cascade.",
                     Self::drain_bus_errors(&pipeline)
                 );
+                // Zero-copy dmabuf -> VAAPI, only when the caller confirmed VAAPI is usable.
+                if prefer_dmabuf {
+                    if let Ok((p, a)) = Self::build_dmabuf(&capturable) {
+                        if Self::try_reach_playing(&p, 3) {
+                            let mut r = Self::finish(p, a);
+                            r.is_dmabuf = true;
+                            return Ok(r);
+                        }
+                        let _ = p.set_state(gst::State::Null);
+                    }
+                    debug!("Dmabuf path unavailable; falling back to LinearCpu.");
+                }
+                if let Ok((p, a)) = Self::build_linear_cpu(&capturable) {
+                    if Self::try_reach_playing(&p, 3) {
+                        return Ok(Self::finish(p, a));
+                    }
+                    let _ = p.set_state(gst::State::Null);
+                }
+                debug!("LinearCpu path unavailable; falling back to GL.");
                 Self::start(Self::build_gl(&capturable)?)
             }
         }
@@ -386,6 +456,97 @@ impl PipeWireRecorder {
         Ok((pipeline, appsink))
     }
 
+    /// Zero-copy path: keep the PipeWire buffer as a DMA_DRM dmabuf and hand its fd
+    /// downstream (to `lib/encode_video.c`'s hwmap import). No GPU download, no colour
+    /// convert — the VAAPI encoder consumes the tiled buffer directly.
+    ///
+    /// `always-copy` MUST be false (same reason as `build_gl`): niri stores the data in
+    /// the fd with a 1-byte system chunk, so a copy would drop the fd we need. The
+    /// capsfilter restricts to single-plane non-CCS modifiers `XR24_NONCCS`.
+    fn build_dmabuf(
+        capturable: &PipeWireCapturable,
+    ) -> Result<(gst::Pipeline, AppSink), Box<dyn Error>> {
+        let pipeline = gst::Pipeline::new();
+        let src = Self::make_src(capturable, false)?;
+        let capsfilter = gst::ElementFactory::make("capsfilter").build()?;
+        capsfilter.set_property(
+            "caps",
+            &XR24_NONCCS
+                .parse::<gst::Caps>()
+                .map_err(|e| GStreamerError(format!("Failed to parse dmabuf caps: {e}")))?,
+        );
+        let appsink = gst::ElementFactory::make("appsink").build()?;
+        appsink.set_property("drop", &true);
+        appsink.set_property("max-buffers", &1u32);
+        let appsink = appsink
+            .dynamic_cast::<AppSink>()
+            .map_err(|_| GStreamerError("Sink element is expected to be an appsink!".into()))?;
+        // Keep the buffer as a DMA_DRM dmabuf — do NOT download to system memory.
+        appsink.set_caps(Some(
+            &"video/x-raw(memory:DMABuf), format=(string)DMA_DRM"
+                .parse::<gst::Caps>()
+                .map_err(|e| GStreamerError(format!("Failed to parse appsink caps: {e}")))?,
+        ));
+        let sink = appsink.clone().upcast::<gst::Element>();
+        pipeline.add_many([&src, &capsfilter, &sink])?;
+        src.link(&capsfilter)
+            .map_err(|e| GStreamerError(format!("Failed to link pipewiresrc -> capsfilter: {e}")))?;
+        capsfilter
+            .link(&sink)
+            .map_err(|e| GStreamerError(format!("Failed to link capsfilter -> appsink: {e}")))?;
+        Ok((pipeline, appsink))
+    }
+
+    /// Cheap-readback CPU path: identical to `build_gl` but the capsfilter forces a LINEAR
+    /// modifier (`XR24_LINEAR`), so `gldownload` copies untiled pixels back to system
+    /// memory with no de-tile cost. Yields the same `BGRx`/`RGBx` any encoder accepts.
+    fn build_linear_cpu(
+        capturable: &PipeWireCapturable,
+    ) -> Result<(gst::Pipeline, AppSink), Box<dyn Error>> {
+        if gst::ElementFactory::find("glupload").is_none()
+            || gst::ElementFactory::find("gldownload").is_none()
+        {
+            return Err(Box::new(GStreamerError(
+                "GL DMA-BUF import needed for the linear-cpu path but glupload/gldownload are \
+                 unavailable (install gstreamer gl plugins)."
+                    .into(),
+            )));
+        }
+
+        let pipeline = gst::Pipeline::new();
+        let src = Self::make_src(capturable, false)?;
+
+        let dmabuf_caps: gst::Caps = XR24_LINEAR
+            .parse()
+            .map_err(|e| GStreamerError(format!("Failed to parse LINEAR DMA-BUF caps: {e}")))?;
+        let capsfilter = gst::ElementFactory::make("capsfilter").build()?;
+        capsfilter.set_property("caps", &dmabuf_caps);
+
+        let glupload = gst::ElementFactory::make("glupload").build()?;
+        let glcolorconvert = gst::ElementFactory::make("glcolorconvert").build()?;
+        let gldownload = gst::ElementFactory::make("gldownload").build()?;
+        let videoconvert = gst::ElementFactory::make("videoconvert").build()?;
+        let appsink = Self::make_appsink()?;
+        let sink = appsink.clone().upcast::<gst::Element>();
+
+        let elements = [
+            src,
+            capsfilter,
+            glupload,
+            glcolorconvert,
+            gldownload,
+            videoconvert,
+            sink,
+        ];
+        pipeline.add_many(&elements)?;
+        for w in elements.windows(2) {
+            w[0].link(&w[1]).map_err(|e| {
+                GStreamerError(format!("Failed to link {} -> {}: {e}", w[0].name(), w[1].name()))
+            })?;
+        }
+        Ok((pipeline, appsink))
+    }
+
     /// Drive a pipeline to PLAYING, returning `true` if it actually got there. Used to
     /// probe the direct path in `auto` mode: a compositor that only offers DMA-BUF makes
     /// negotiation fail (`not-negotiated`) and the state change reports failure quickly.
@@ -457,12 +618,82 @@ impl PipeWireRecorder {
             height: 0,
             buffer_cropped: vec![],
             is_cropped: false,
+            is_dmabuf: false,
+            dmabuf: None,
         }
     }
 }
 
 impl Recorder for PipeWireRecorder {
+    fn is_dmabuf(&self) -> bool {
+        self.is_dmabuf
+    }
+
     fn capture(&mut self) -> Result<PixelProvider<'_>, Box<dyn Error>> {
+        // Zero-copy path: pull a DMA_DRM dmabuf, retain the buffer (keeps the fd valid)
+        // and hand its DRM layout downstream. Reuse the previous frame if none is ready.
+        if self.is_dmabuf {
+            if let Some(sample) = self
+                .appsink
+                .try_pull_sample(gst::ClockTime::from_mseconds(16))
+            {
+                let caps = sample
+                    .caps()
+                    .ok_or_else(|| GStreamerError("dmabuf sample has no caps".into()))?;
+                let s = caps
+                    .structure(0)
+                    .ok_or_else(|| GStreamerError("dmabuf caps has no structure".into()))?;
+                let w: i32 = s.value("width")?.get()?;
+                let h: i32 = s.value("height")?.get()?;
+                // The negotiated drm-format carries the ACTUAL modifier the compositor
+                // chose (LINEAR / X_TILED / Y_TILED). It must reach the DRM-PRIME
+                // descriptor or a tiled buffer is imported as linear -> scrambled frame.
+                let drm_format = s
+                    .value("drm-format")
+                    .ok()
+                    .and_then(|v| v.get::<String>().ok())
+                    .unwrap_or_default();
+                let modifier = parse_drm_modifier(&drm_format);
+                let buffer = sample
+                    .buffer_owned()
+                    .ok_or_else(|| GStreamerError("dmabuf sample has no buffer".into()))?;
+                let vmeta = buffer.meta::<gstreamer_video::VideoMeta>();
+                let stride = vmeta.as_ref().map(|m| m.stride()[0]).unwrap_or(w * 4) as u32;
+                let offset = vmeta.as_ref().map(|m| m.offset()[0]).unwrap_or(0) as u32;
+                let fd = buffer
+                    .peek_memory(0)
+                    .downcast_memory_ref::<gstreamer_allocators::DmaBufMemory>()
+                    .map(|m| m.fd())
+                    .ok_or_else(|| GStreamerError("buffer memory is not a DmaBufMemory".into()))?;
+                // Log the negotiated layout once (or whenever it changes) for diagnosis.
+                let changed = self
+                    .dmabuf
+                    .as_ref()
+                    .map(|d| d.6 != modifier || d.3 != stride || d.1 != w as usize)
+                    .unwrap_or(true);
+                if changed {
+                    debug!(
+                        "dmabuf frame: {}x{} drm-format={:?} modifier={:#018x} stride={} offset={}",
+                        w, h, drm_format, modifier, stride, offset
+                    );
+                }
+                self.dmabuf = Some((buffer, w as usize, h as usize, stride, offset, fd, modifier));
+            }
+            let (_, w, h, stride, offset, fd, modifier) = self
+                .dmabuf
+                .as_ref()
+                .ok_or_else(|| GStreamerError("No dmabuf frame available!".into()))?;
+            return Ok(PixelProvider::DmaBuf {
+                fd: *fd,
+                // DRM_FORMAT_XRGB8888 = 'X','R','2','4' little-endian.
+                fourcc: u32::from_le_bytes([b'X', b'R', b'2', b'4']),
+                modifier: *modifier,
+                width: *w,
+                height: *h,
+                stride: *stride,
+                offset: *offset,
+            });
+        }
         if let Some(sample) = self
             .appsink
             .try_pull_sample(gst::ClockTime::from_mseconds(16))
@@ -926,6 +1157,28 @@ pub fn get_capturables(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn drm_modifier_bare_fourcc_is_linear() {
+        assert_eq!(parse_drm_modifier("XR24"), 0);
+    }
+
+    #[test]
+    fn drm_modifier_parses_tiled_suffix() {
+        // Y_TILED and X_TILED as niri/Intel negotiate them.
+        assert_eq!(parse_drm_modifier("XR24:0x0100000000000002"), 0x0100000000000002);
+        assert_eq!(parse_drm_modifier("XR24:0x0100000000000001"), 0x0100000000000001);
+    }
+
+    #[test]
+    fn drm_modifier_explicit_linear_suffix() {
+        assert_eq!(parse_drm_modifier("XR24:0x0000000000000000"), 0);
+    }
+
+    #[test]
+    fn drm_modifier_garbage_falls_back_to_linear() {
+        assert_eq!(parse_drm_modifier("XR24:nonsense"), 0);
+    }
 
     fn rel(g: &Geometry) -> (f64, f64, f64, f64) {
         match g {

--- a/src/capturable/pipewire.rs
+++ b/src/capturable/pipewire.rs
@@ -187,17 +187,12 @@ impl Capturable for PipeWireCapturable {
     }
 
     fn geometry(&self) -> Result<Geometry, Box<dyn Error>> {
-        let geometry =
-            relative_geometry(self.source_type, self.position, self.size, self.global_box);
-        // On Linux `Geometry` only has the `Relative` variant, so this destructure is
-        // irrefutable; it is purely to log the resolved mapping.
-        let Geometry::Relative(x, y, w, h) = geometry;
-        debug!(
-            "geometry() for path {} (source_type {}): stream position {:?} size {:?}, \
-             global_box {:?} -> Relative(x={:.4}, y={:.4}, w={:.4}, h={:.4})",
-            self.path, self.source_type, self.position, self.size, self.global_box, x, y, w, h
-        );
-        Ok(geometry)
+        Ok(relative_geometry(
+            self.source_type,
+            self.position,
+            self.size,
+            self.global_box,
+        ))
     }
 
     fn before_input(&mut self) -> Result<(), Box<dyn Error>> {

--- a/src/capturable/pipewire.rs
+++ b/src/capturable/pipewire.rs
@@ -17,6 +17,7 @@ use gstreamer::prelude::*;
 use gstreamer_app::AppSink;
 
 use crate::capturable::{Capturable, Geometry, Recorder};
+use crate::config::PipewirePipeline;
 use crate::video::PixelProvider;
 
 use crate::capturable::remote_desktop_dbus::{
@@ -61,15 +62,22 @@ pub struct PipeWireCapturable {
     fd: OwnedFd,
     path: u64,
     source_type: u64,
+    pipeline: PipewirePipeline,
 }
 
 impl PipeWireCapturable {
-    fn new(conn: Arc<SyncConnection>, fd: OwnedFd, stream: PwStreamInfo) -> Self {
+    fn new(
+        conn: Arc<SyncConnection>,
+        fd: OwnedFd,
+        stream: PwStreamInfo,
+        pipeline: PipewirePipeline,
+    ) -> Self {
         Self {
             dbus_conn: conn,
             fd,
             path: stream.path,
             source_type: stream.source_type,
+            pipeline,
         }
     }
 }
@@ -78,11 +86,12 @@ impl std::fmt::Debug for PipeWireCapturable {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "PipeWireCapturable {{dbus: {}, fd: {}, path: {}, source_type: {}}}",
+            "PipeWireCapturable {{dbus: {}, fd: {}, path: {}, source_type: {}, pipeline: {:?}}}",
             self.dbus_conn.unique_name(),
             self.fd.as_raw_fd(),
             self.path,
-            self.source_type
+            self.source_type,
+            self.pipeline,
         )
     }
 }
@@ -123,22 +132,72 @@ pub struct PipeWireRecorder {
 
 impl PipeWireRecorder {
     pub fn new(capturable: PipeWireCapturable) -> Result<Self, Box<dyn Error>> {
-        let pipeline = gst::Pipeline::new();
+        // Two pipelines can turn a PipeWire screen-cast stream into the system-memory
+        // `BGRx`/`RGBx` the appsink (and x264 encoder) need:
+        //
+        //  * DIRECT  `pipewiresrc -> appsink` -- the historic path. Works only where the
+        //    compositor/backend hands back CPU-mappable buffers (system memory, or a
+        //    linear dmabuf pipewiresrc can map). Cheapest: no GPU, no colour convert.
+        //  * GL      `pipewiresrc -> capsfilter -> glupload -> glcolorconvert ->
+        //    gldownload -> videoconvert -> appsink` -- required for compositors that only
+        //    offer tiled/modified DMA-BUF (niri, modern sway/KDE/GNOME). Imports the
+        //    dmabuf on the GPU and downloads it. Costs an EGL import + GPU convert + a
+        //    read-back per frame, and needs a working GL/EGL context.
+        //
+        // The strategy comes from the GUI / config (`--pipewire-pipeline`), stored on the
+        // capturable. The `WEYLUS_PIPEWIRE_PIPELINE` env var still overrides it for quick
+        // debugging without touching config.
+        //    Auto   -- try DIRECT, fall back to GL if it fails to negotiate.
+        //    Direct -- force DIRECT.
+        //    Gl     -- force GL.
+        // `Auto` keeps the direct path (and its zero overhead) on setups where it always
+        // worked, and only pays the GL cost where the direct path can't negotiate.
+        let mode = match std::env::var("WEYLUS_PIPEWIRE_PIPELINE")
+            .unwrap_or_default()
+            .to_ascii_lowercase()
+            .as_str()
+        {
+            "direct" => PipewirePipeline::Direct,
+            "gl" => PipewirePipeline::Gl,
+            "auto" => PipewirePipeline::Auto,
+            _ => capturable.pipeline,
+        };
 
+        match mode {
+            PipewirePipeline::Direct => Self::start(Self::build_direct(&capturable)?),
+            PipewirePipeline::Gl => Self::start(Self::build_gl(&capturable)?),
+            PipewirePipeline::Auto => {
+                // probe the cheap direct path first.
+                let (pipeline, appsink) = Self::build_direct(&capturable)?;
+                if Self::try_reach_playing(&pipeline, 3) {
+                    return Ok(Self::finish(pipeline, appsink));
+                }
+                let _ = pipeline.set_state(gst::State::Null);
+                debug!(
+                    "Direct pipewiresrc path did not negotiate ({}); falling back to \
+                     GL DMA-BUF import.",
+                    Self::drain_bus_errors(&pipeline)
+                );
+                Self::start(Self::build_gl(&capturable)?)
+            }
+        }
+    }
+
+    fn make_src(
+        capturable: &PipeWireCapturable,
+        always_copy: bool,
+    ) -> Result<gst::Element, Box<dyn Error>> {
         let src = gst::ElementFactory::make("pipewiresrc").build()?;
         src.set_property("fd", &capturable.fd.as_raw_fd());
         src.set_property("path", &format!("{}", capturable.path));
+        src.set_property("always-copy", &always_copy);
+        Ok(src)
+    }
 
-        // For some reason pipewire blocks on destruction of AppSink if this is not set to true,
-        // see: https://gitlab.freedesktop.org/pipewire/pipewire/-/issues/982
-        src.set_property("always-copy", &true);
-
+    fn make_appsink() -> Result<AppSink, Box<dyn Error>> {
         let sink = gst::ElementFactory::make("appsink").build()?;
         sink.set_property("drop", &true);
         sink.set_property("max-buffers", &1u32);
-
-        pipeline.add_many(&[&src, &sink])?;
-        src.link(&sink)?;
         let appsink = sink
             .dynamic_cast::<AppSink>()
             .map_err(|_| GStreamerError("Sink element is expected to be an appsink!".into()))?;
@@ -152,9 +211,159 @@ impl PipeWireRecorder {
             [("format", "RGBx".into())],
         ));
         appsink.set_caps(Some(&caps));
+        Ok(appsink)
+    }
 
-        pipeline.set_state(gst::State::Playing)?;
-        Ok(Self {
+    /// Historic `pipewiresrc -> appsink` path. `always-copy=true` matches the original
+    /// behaviour (it also works around a PipeWire teardown hang, pw#982) and is safe here
+    /// because this path only negotiates CPU-mappable buffers.
+    fn build_direct(
+        capturable: &PipeWireCapturable,
+    ) -> Result<(gst::Pipeline, AppSink), Box<dyn Error>> {
+        let pipeline = gst::Pipeline::new();
+        let src = Self::make_src(capturable, true)?;
+        let appsink = Self::make_appsink()?;
+        let sink = appsink.clone().upcast::<gst::Element>();
+        pipeline.add_many([&src, &sink])?;
+        src.link(&sink)
+            .map_err(|e| GStreamerError(format!("Failed to link pipewiresrc -> appsink: {e}")))?;
+        Ok((pipeline, appsink))
+    }
+
+    /// GL DMA-BUF import path for compositors that only offer tiled/modified DMA-BUF.
+    ///
+    /// glupload imports the dmabuf as an EGLImage (fd + fourcc + modifier), the GPU does
+    /// the de-tiling / colour convert, `gldownload` copies it back to system memory and
+    /// `videoconvert` guarantees the `BGRx`/`RGBx` the appsink wants.
+    ///
+    /// The capsfilter restricts negotiation to single-plane, non-CCS modifiers
+    /// (LINEAR + X_TILED + Y_TILED). niri defaults to a *CCS* modifier
+    /// (Y_TILED_GEN12_MC_CCS = 0x0100000000000008); CCS is multi-plane (colour buffer +
+    /// a control-surface plane) but the screen-cast stream carries only one plane, so
+    /// `eglCreateImage` rejects it with `EGL_BAD_MATCH` and glupload falls through to a
+    /// CPU path that cannot map the buffer -> black screen. A bare fourcc (no
+    /// `:modifier`) means LINEAR and doubles as the portable fallback for non-Intel GPUs.
+    /// `always-copy` MUST be false: niri sets chunk->size = maxsize = 1 on its dmabufs
+    /// (the data lives in the fd), so a copy would keep a 1-byte system buffer and drop
+    /// the fd the GL importer needs.
+    ///
+    /// NB: a *list* of alternative drm-formats must use `{ }` (GstValueList). `< >` builds
+    /// a GstValueArray (an ordered fixed tuple) that does NOT intersect the list-valued
+    /// `drm-format` sink caps downstream, so the link fails silently.
+    fn build_gl(
+        capturable: &PipeWireCapturable,
+    ) -> Result<(gst::Pipeline, AppSink), Box<dyn Error>> {
+        if gst::ElementFactory::find("glupload").is_none()
+            || gst::ElementFactory::find("gldownload").is_none()
+        {
+            return Err(Box::new(GStreamerError(
+                "GL DMA-BUF import needed for this compositor but glupload/gldownload are \
+                 unavailable (install gstreamer gl plugins)."
+                    .into(),
+            )));
+        }
+
+        let pipeline = gst::Pipeline::new();
+        let src = Self::make_src(capturable, false)?;
+
+        let dmabuf_caps: gst::Caps = "video/x-raw(memory:DMABuf), format=(string)DMA_DRM, \
+             width=(int)[1,32767], height=(int)[1,32767], \
+             framerate=(fraction)[0/1,2147483647/1], drm-format=(list){ \
+             (string)XR24, (string)XR24:0x0100000000000001, (string)XR24:0x0100000000000002, \
+             (string)AR24, (string)AR24:0x0100000000000001, (string)AR24:0x0100000000000002 }"
+            .parse()
+            .map_err(|e| GStreamerError(format!("Failed to parse DMA-BUF caps: {e}")))?;
+        let capsfilter = gst::ElementFactory::make("capsfilter").build()?;
+        capsfilter.set_property("caps", &dmabuf_caps);
+
+        let glupload = gst::ElementFactory::make("glupload").build()?;
+        let glcolorconvert = gst::ElementFactory::make("glcolorconvert").build()?;
+        let gldownload = gst::ElementFactory::make("gldownload").build()?;
+        let videoconvert = gst::ElementFactory::make("videoconvert").build()?;
+        let appsink = Self::make_appsink()?;
+        let sink = appsink.clone().upcast::<gst::Element>();
+
+        let elements = [
+            src,
+            capsfilter,
+            glupload,
+            glcolorconvert,
+            gldownload,
+            videoconvert,
+            sink,
+        ];
+        pipeline.add_many(&elements)?;
+        for w in elements.windows(2) {
+            w[0].link(&w[1]).map_err(|e| {
+                GStreamerError(format!("Failed to link {} -> {}: {e}", w[0].name(), w[1].name()))
+            })?;
+        }
+        Ok((pipeline, appsink))
+    }
+
+    /// Drive a pipeline to PLAYING, returning `true` if it actually got there. Used to
+    /// probe the direct path in `auto` mode: a compositor that only offers DMA-BUF makes
+    /// negotiation fail (`not-negotiated`) and the state change reports failure quickly.
+    fn try_reach_playing(pipeline: &gst::Pipeline, timeout_secs: u64) -> bool {
+        match pipeline.set_state(gst::State::Playing) {
+            Err(_) => false,
+            Ok(gst::StateChangeSuccess::Success) | Ok(gst::StateChangeSuccess::NoPreroll) => true,
+            Ok(gst::StateChangeSuccess::Async) => pipeline
+                .state(gst::ClockTime::from_seconds(timeout_secs))
+                .0
+                .is_ok(),
+        }
+    }
+
+    /// Collect ERROR messages from the pipeline bus. GStreamer's own GST_DEBUG output does
+    /// not reach stderr from weylus, so the bus is the only place the real
+    /// caps-negotiation / import reason (e.g. pipewiresrc "not-negotiated" or "Internal
+    /// data stream error") is available.
+    fn drain_bus_errors(pipeline: &gst::Pipeline) -> String {
+        let bus = match pipeline.bus() {
+            Some(b) => b,
+            None => return "no bus available".into(),
+        };
+        let mut msgs = Vec::new();
+        while let Some(msg) = bus
+            .timed_pop_filtered(gst::ClockTime::from_mseconds(500), &[gst::MessageType::Error])
+        {
+            if let gst::MessageView::Error(err) = msg.view() {
+                let src = err
+                    .src()
+                    .map(|s| s.path_string().to_string())
+                    .unwrap_or_else(|| "?".into());
+                msgs.push(format!(
+                    "[{src}] {} (debug: {})",
+                    err.error(),
+                    err.debug().unwrap_or_else(|| "none".into())
+                ));
+            }
+        }
+        if msgs.is_empty() {
+            "no error message on bus".into()
+        } else {
+            msgs.join("; ")
+        }
+    }
+
+    /// Start a pre-built pipeline, surfacing the real GStreamer error if it cannot reach
+    /// PLAYING (instead of the generic "Element failed to change its state!").
+    fn start(built: (gst::Pipeline, AppSink)) -> Result<Self, Box<dyn Error>> {
+        let (pipeline, appsink) = built;
+        if Self::try_reach_playing(&pipeline, 5) {
+            Ok(Self::finish(pipeline, appsink))
+        } else {
+            let reason = Self::drain_bus_errors(&pipeline);
+            let _ = pipeline.set_state(gst::State::Null);
+            Err(Box::new(GStreamerError(format!(
+                "Failed to start pipewire pipeline: {reason}"
+            ))))
+        }
+    }
+
+    fn finish(pipeline: gst::Pipeline, appsink: AppSink) -> Self {
+        Self {
             pipeline,
             appsink,
             buffer: None,
@@ -163,7 +372,7 @@ impl PipeWireRecorder {
             height: 0,
             buffer_cropped: vec![],
             is_cropped: false,
-        })
+        }
     }
 }
 
@@ -527,7 +736,6 @@ fn on_start_response(
     if let Some(Some(t)) = r.results.get("restore_token").map(|t| t.as_str()) {
         context.restore_token = Some(t.to_string());
     }
-    dbg!(&context.restore_token);
     if context.has_remote_desktop {
         debug!("Remote Desktop Session started");
     } else {
@@ -599,11 +807,14 @@ fn request_remote_desktop(
     }
 }
 
-pub fn get_capturables(capture_cursor: bool) -> Result<Vec<PipeWireCapturable>, Box<dyn Error>> {
+pub fn get_capturables(
+    capture_cursor: bool,
+    pipeline: PipewirePipeline,
+) -> Result<Vec<PipeWireCapturable>, Box<dyn Error>> {
     let (conn, fd, streams) = request_remote_desktop(capture_cursor)?;
     let conn = Arc::new(conn);
     Ok(streams
         .into_iter()
-        .map(|s| PipeWireCapturable::new(conn.clone(), fd.clone(), s))
+        .map(|s| PipeWireCapturable::new(conn.clone(), fd.clone(), s, pipeline))
         .collect())
 }

--- a/src/capturable/testsrc.rs
+++ b/src/capturable/testsrc.rs
@@ -74,7 +74,7 @@ impl Capturable for TestCapturable {
     fn before_input(&mut self) -> Result<(), Box<dyn Error>> {
         Ok(())
     }
-    fn recorder(&self, _: bool) -> Result<Box<dyn Recorder>, Box<dyn Error>> {
+    fn recorder(&self, _: bool, _: bool) -> Result<Box<dyn Recorder>, Box<dyn Error>> {
         Ok(Box::new(TestRecorder::new(*self)))
     }
 }

--- a/src/capturable/wayland_outputs.rs
+++ b/src/capturable/wayland_outputs.rs
@@ -1,0 +1,200 @@
+//! Wayland output geometry, used to map stylus input onto the right monitor.
+//!
+//! The ScreenCast portal hands weylus each captured monitor's rect (`position`/`size`)
+//! in the compositor's LOGICAL coordinate space. But the compositor scales the tablet's
+//! absolute axes against the *global* bounding rectangle (the union of all outputs), not
+//! against a single output. So to turn a portal rect into the `Geometry::Relative`
+//! fraction weylus needs, we must divide it by that global box.
+//!
+//! The portal does not report the global box, so we enumerate outputs ourselves via
+//! `wl_output` + the `xdg-output` extension (which reports each output's logical
+//! position/size directly). This is compositor-agnostic — no `niri msg`, no reliance on
+//! which outputs the portal happened to return.
+//!
+//! This whole module is Linux-only (same `cfg(target_os = "linux")` gate as the rest of
+//! the PipeWire/Wayland path) and is only exercised when the Wayland capture checkbox is
+//! enabled. Any failure (no Wayland display, no `xdg-output`) returns `None`, and the
+//! caller falls back to the historic whole-screen mapping.
+
+use smithay_client_toolkit::output::{OutputHandler, OutputState};
+use smithay_client_toolkit::reexports::client::globals::registry_queue_init;
+use smithay_client_toolkit::reexports::client::protocol::wl_output::WlOutput;
+use smithay_client_toolkit::reexports::client::{Connection, QueueHandle};
+use smithay_client_toolkit::registry::{ProvidesRegistryState, RegistryState};
+use smithay_client_toolkit::{delegate_output, delegate_registry, registry_handlers};
+use tracing::debug;
+
+/// Global bounding box of all outputs in the compositor's logical coordinate space:
+/// `(x, y, width, height)`. This is the space the compositor decodes tablet ABS axes
+/// against, so it is what a per-monitor portal rect must be normalised by.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GlobalBox {
+    pub x: i32,
+    pub y: i32,
+    pub width: i32,
+    pub height: i32,
+}
+
+struct AppData {
+    registry_state: RegistryState,
+    output_state: OutputState,
+}
+
+impl OutputHandler for AppData {
+    fn output_state(&mut self) -> &mut OutputState {
+        &mut self.output_state
+    }
+    // We read the accumulated state after roundtrips, so the callbacks are no-ops.
+    fn new_output(&mut self, _: &Connection, _: &QueueHandle<Self>, _: WlOutput) {}
+    fn update_output(&mut self, _: &Connection, _: &QueueHandle<Self>, _: WlOutput) {}
+    fn output_destroyed(&mut self, _: &Connection, _: &QueueHandle<Self>, _: WlOutput) {}
+}
+
+delegate_output!(AppData);
+delegate_registry!(AppData);
+
+impl ProvidesRegistryState for AppData {
+    fn registry(&mut self) -> &mut RegistryState {
+        &mut self.registry_state
+    }
+    registry_handlers![OutputState];
+}
+
+/// Query the global bounding box of all Wayland outputs via `xdg-output`.
+///
+/// Returns `None` (and logs) if there is no Wayland display, the compositor does not
+/// expose `xdg-output`, or no output reports logical geometry — in which case the caller
+/// should fall back to the historic whole-screen mapping.
+pub fn global_bounding_box() -> Option<GlobalBox> {
+    let conn = match Connection::connect_to_env() {
+        Ok(c) => c,
+        Err(e) => {
+            debug!("No Wayland connection for output geometry: {e}");
+            return None;
+        }
+    };
+    let (globals, mut event_queue) = match registry_queue_init::<AppData>(&conn) {
+        Ok(v) => v,
+        Err(e) => {
+            debug!("Wayland registry init failed: {e}");
+            return None;
+        }
+    };
+    let qh = event_queue.handle();
+    let mut app = AppData {
+        registry_state: RegistryState::new(&globals),
+        output_state: OutputState::new(&globals, &qh),
+    };
+
+    // First roundtrip: wl_output globals + their wl_output events.
+    // Second: the follow-up xdg_output events carrying logical_position/logical_size.
+    if let Err(e) = event_queue.roundtrip(&mut app) {
+        debug!("Wayland roundtrip failed: {e}");
+        return None;
+    }
+    if let Err(e) = event_queue.roundtrip(&mut app) {
+        debug!("Wayland roundtrip failed: {e}");
+        return None;
+    }
+
+    let infos: Vec<_> = app
+        .output_state
+        .outputs()
+        .filter_map(|o| app.output_state.info(&o))
+        .collect();
+
+    let mut rects: Vec<(i32, i32, i32, i32)> = Vec::new();
+    for info in &infos {
+        let name = info.name.as_deref().unwrap_or("<unnamed>");
+        match (info.logical_position, info.logical_size) {
+            (Some((x, y)), Some((w, h))) => {
+                debug!(
+                    "Wayland output {name} (id {}): logical position ({x}, {y}) size {w}x{h}, \
+                     scale {}",
+                    info.id, info.scale_factor
+                );
+                rects.push((x, y, w, h));
+            }
+            _ => debug!(
+                "Wayland output {name} (id {}): no xdg-output logical geometry, skipping",
+                info.id
+            ),
+        }
+    }
+
+    let bbox = bounding_box(&rects);
+    match bbox {
+        Some(b) => debug!(
+            "Wayland global bounding box (union of {} output(s)): position ({}, {}) size {}x{}",
+            rects.len(),
+            b.x,
+            b.y,
+            b.width,
+            b.height
+        ),
+        None => debug!("No Wayland outputs reported logical geometry; global box unavailable"),
+    }
+    bbox
+}
+
+/// Union of logical rects `(x, y, w, h)` into a `GlobalBox`. `None` if empty.
+fn bounding_box(rects: &[(i32, i32, i32, i32)]) -> Option<GlobalBox> {
+    let mut it = rects.iter();
+    let &(x0, y0, w0, h0) = it.next()?;
+    let mut min_x = x0;
+    let mut min_y = y0;
+    let mut max_x = x0 + w0;
+    let mut max_y = y0 + h0;
+    for &(x, y, w, h) in it {
+        min_x = min_x.min(x);
+        min_y = min_y.min(y);
+        max_x = max_x.max(x + w);
+        max_y = max_y.max(y + h);
+    }
+    Some(GlobalBox {
+        x: min_x,
+        y: min_y,
+        width: max_x - min_x,
+        height: max_y - min_y,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bounding_box_of_measured_dual_monitor_setup() {
+        // The exact logical rects this box reports (coords.txt): DP-1 + eDP-1.
+        let rects = [(0, 0, 4096, 1728), (1328, 1728, 1440, 960)];
+        assert_eq!(
+            bounding_box(&rects),
+            Some(GlobalBox {
+                x: 0,
+                y: 0,
+                width: 4096,
+                height: 2688,
+            })
+        );
+    }
+
+    #[test]
+    fn bounding_box_handles_negative_origin() {
+        // Output to the left of / above the primary => negative coordinates.
+        let rects = [(0, 0, 1920, 1080), (-1280, -200, 1280, 1024)];
+        assert_eq!(
+            bounding_box(&rects),
+            Some(GlobalBox {
+                x: -1280,
+                y: -200,
+                width: 1920 + 1280,
+                height: 1080 + 200,
+            })
+        );
+    }
+
+    #[test]
+    fn bounding_box_empty_is_none() {
+        assert_eq!(bounding_box(&[]), None);
+    }
+}

--- a/src/capturable/x11.rs
+++ b/src/capturable/x11.rs
@@ -136,7 +136,11 @@ impl Capturable for X11Capturable {
         }
     }
 
-    fn recorder(&self, capture_cursor: bool) -> Result<Box<dyn Recorder>, Box<dyn Error>> {
+    fn recorder(
+        &self,
+        capture_cursor: bool,
+        _prefer_dmabuf: bool,
+    ) -> Result<Box<dyn Recorder>, Box<dyn Error>> {
         match RecorderX11::new(self.clone(), capture_cursor) {
             Ok(recorder) => Ok(Box::new(recorder)),
             Err(err) => Err(Box::new(err)),

--- a/src/config.rs
+++ b/src/config.rs
@@ -81,13 +81,21 @@ pub enum PipewirePipeline {
     Direct,
     /// Force the GL DMA-BUF import path (`glupload -> ... -> gldownload`).
     Gl,
+    /// Force zero-copy dmabuf import into VAAPI (`pipewiresrc -> appsink(DMA_DRM)`
+    /// then ffmpeg hwmap). Only works with the VAAPI encoder.
+    Dmabuf,
+    /// Force the GL download path pinned to a LINEAR modifier for a cheap
+    /// (no de-tile) readback to system memory.
+    LinearCpu,
 }
 
 #[cfg(target_os = "linux")]
-const PIPEWIRE_PIPELINE_LIST: [PipewirePipeline; 3] = [
+const PIPEWIRE_PIPELINE_LIST: [PipewirePipeline; 5] = [
     PipewirePipeline::Auto,
-    PipewirePipeline::Direct,
+    PipewirePipeline::Dmabuf,
+    PipewirePipeline::LinearCpu,
     PipewirePipeline::Gl,
+    PipewirePipeline::Direct,
 ];
 
 #[cfg(target_os = "linux")]
@@ -105,6 +113,8 @@ impl PipewirePipeline {
             PipewirePipeline::Auto => "Auto",
             PipewirePipeline::Direct => "Direct",
             PipewirePipeline::Gl => "GL",
+            PipewirePipeline::Dmabuf => "Zero-copy (DMA-BUF)",
+            PipewirePipeline::LinearCpu => "Linear CPU",
         }
         .to_string()
     }
@@ -176,7 +186,7 @@ pub struct Config {
         long,
         value_enum,
         default_value = "auto",
-        help = "PipeWire capture pipeline: auto (probe direct, fall back to GL), direct, or gl."
+        help = "PipeWire capture pipeline: auto, dmabuf (zero-copy VAAPI), linear-cpu, gl, or direct."
     )]
     #[serde(default)]
     pub pipewire_pipeline: crate::config::PipewirePipeline,
@@ -275,5 +285,22 @@ pub fn get_config() -> Config {
         config
     } else {
         Config::parse()
+    }
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::*;
+    #[test]
+    fn pipeline_list_has_all_five_variants() {
+        let v = PipewirePipeline::variants();
+        assert_eq!(v.len(), 5);
+        assert!(v.contains(&PipewirePipeline::Dmabuf));
+        assert!(v.contains(&PipewirePipeline::LinearCpu));
+    }
+    #[test]
+    fn pipeline_names_are_stable() {
+        assert_eq!(PipewirePipeline::Dmabuf.name(), "Zero-copy (DMA-BUF)");
+        assert_eq!(PipewirePipeline::LinearCpu.name(), "Linear CPU");
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -68,6 +68,64 @@ impl ThemeType {
     }
 }
 
+/// Which GStreamer pipeline the PipeWire (Wayland) capturer uses to turn the
+/// compositor's screen-cast stream into CPU-mappable pixels.
+#[cfg(target_os = "linux")]
+#[derive(clap::ValueEnum, Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PipewirePipeline {
+    /// Try the cheap direct path, fall back to the GL DMA-BUF import if it can
+    /// not negotiate (needed for niri and most modern Wayland compositors).
+    Auto,
+    /// Force `pipewiresrc -> appsink`. Only works where the compositor exposes
+    /// CPU-mappable buffers; cheapest when it does.
+    Direct,
+    /// Force the GL DMA-BUF import path (`glupload -> ... -> gldownload`).
+    Gl,
+}
+
+#[cfg(target_os = "linux")]
+const PIPEWIRE_PIPELINE_LIST: [PipewirePipeline; 3] = [
+    PipewirePipeline::Auto,
+    PipewirePipeline::Direct,
+    PipewirePipeline::Gl,
+];
+
+#[cfg(target_os = "linux")]
+impl Default for PipewirePipeline {
+    fn default() -> Self {
+        Self::Auto
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl PipewirePipeline {
+    /// Human-readable label for the GUI dropdown.
+    pub fn name(&self) -> String {
+        match self {
+            PipewirePipeline::Auto => "Auto",
+            PipewirePipeline::Direct => "Direct",
+            PipewirePipeline::Gl => "GL",
+        }
+        .to_string()
+    }
+
+    pub fn to_index(&self) -> i32 {
+        PIPEWIRE_PIPELINE_LIST
+            .iter()
+            .position(|p| p == self)
+            .unwrap_or(0) as i32
+    }
+
+    pub fn from_index(i: i32) -> Self {
+        let i = i.clamp(0, PIPEWIRE_PIPELINE_LIST.len() as i32 - 1) as usize;
+        PIPEWIRE_PIPELINE_LIST[i]
+    }
+
+    pub fn variants() -> &'static [PipewirePipeline] {
+        &PIPEWIRE_PIPELINE_LIST
+    }
+}
+
 #[derive(Serialize, Deserialize, Parser, Debug, Clone)]
 #[command(version, about, long_about = None)]
 pub struct Config {
@@ -113,6 +171,15 @@ pub struct Config {
     #[arg(long, help = "Wayland/PipeWire Support.")]
     #[serde(default)]
     pub wayland_support: bool,
+    #[cfg(target_os = "linux")]
+    #[arg(
+        long,
+        value_enum,
+        default_value = "auto",
+        help = "PipeWire capture pipeline: auto (probe direct, fall back to GL), direct, or gl."
+    )]
+    #[serde(default)]
+    pub pipewire_pipeline: crate::config::PipewirePipeline,
 
     #[arg(long, help = "Print template of index.html served by Weylus.")]
     #[serde(skip)]

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -37,7 +37,7 @@ pub fn run(config: &Config, log_receiver: mpsc::Receiver<String>) {
     let app = App::default().with_scheme(fltk::app::AppScheme::Gtk);
     config.gui_theme.map(|th| th.apply());
     let mut wind = Window::default()
-        .with_size(660, 600)
+        .with_size(660, 640)
         .center_screen()
         .with_label(&format!("Weylus - {}", env!("CARGO_PKG_VERSION")));
     wind.set_xclass("weylus");
@@ -76,10 +76,12 @@ pub fn run(config: &Config, log_receiver: mpsc::Receiver<String>) {
     check_auto_start.set_tooltip("Start Weylus server immediately on program start.");
     check_auto_start.set_checked(config.auto_start);
 
+    // Wayland/PipeWire support gets its own row (below Auto Start), shared with the
+    // PipeWire capture-pipeline selector.
     #[cfg(target_os = "linux")]
     let mut check_wayland = CheckButton::default()
         .with_size(70, height)
-        .right_of(&check_auto_start, 3 * padding)
+        .below_of(&check_auto_start, padding)
         .with_label("Wayland/\nPipeWire\nSupport");
     #[cfg(target_os = "linux")]
     {
@@ -90,6 +92,46 @@ pub fn run(config: &Config, log_receiver: mpsc::Receiver<String>) {
         check_wayland.set_checked(config.wayland_support);
     }
 
+    // PipeWire capture pipeline selector, next to the Wayland toggle.
+    #[cfg(target_os = "linux")]
+    let mut choice_pw_pipeline = Choice::default()
+        .with_size(100, height)
+        .right_of(&check_wayland, 3 * padding);
+    #[cfg(target_os = "linux")]
+    {
+        choice_pw_pipeline.set_tooltip(
+            "Screen-capture pipeline for Wayland/PipeWire. Wayland compositors hand out the \
+             screen as a GPU DMA-BUF, and how it reaches the encoder differs per compositor. \
+             Auto (recommended): try direct capture, fall back to GPU DMA-BUF import (needed \
+             for niri and most modern compositors). Direct: only works where the compositor \
+             exposes plain CPU buffers. GL: force the GPU DMA-BUF import path. Change this \
+             only if capture stays black.",
+        );
+        for p in crate::config::PipewirePipeline::variants() {
+            choice_pw_pipeline.add_choice(&p.name());
+        }
+        choice_pw_pipeline.set_value(config.pipewire_pipeline.to_index());
+        // The selector is meaningless unless Wayland/PipeWire capture is enabled.
+        if !config.wayland_support {
+            choice_pw_pipeline.deactivate();
+        }
+        let mut choice_toggle = choice_pw_pipeline.clone();
+        check_wayland.set_callback(move |cb| {
+            if cb.is_checked() {
+                choice_toggle.activate();
+            } else {
+                choice_toggle.deactivate();
+            }
+        });
+    }
+
+    // Hardware-accel section sits below the Wayland row on Linux, below Auto Start elsewhere.
+    #[cfg(target_os = "linux")]
+    let mut label_hw_accel = Frame::default()
+        .with_size(width, height)
+        .below_of(&check_wayland, padding)
+        .with_label("Try Hardware acceleration");
+    #[cfg(not(target_os = "linux"))]
     let mut label_hw_accel = Frame::default()
         .with_size(width, height)
         .below_of(&check_auto_start, padding)
@@ -229,6 +271,8 @@ pub fn run(config: &Config, log_receiver: mpsc::Receiver<String>) {
                     {
                         config.try_vaapi = check_native_hw_accel.is_checked();
                         config.wayland_support = check_wayland.is_checked();
+                        config.pipewire_pipeline =
+                            crate::config::PipewirePipeline::from_index(choice_pw_pipeline.value());
                     }
                     #[cfg(any(target_os = "linux", target_os = "windows"))]
                     {

--- a/src/main.rs
+++ b/src/main.rs
@@ -158,7 +158,7 @@ mod tests {
     #[bench]
     fn bench_capture_wayland(b: &mut Bencher) {
         gstreamer::init().unwrap();
-        let root = capturable::pipewire::get_capturables(false)
+        let root = capturable::pipewire::get_capturables(false, crate::config::PipewirePipeline::Auto)
             .unwrap()
             .remove(0);
         let mut r = root.recorder(false).unwrap();
@@ -172,7 +172,7 @@ mod tests {
     #[bench]
     fn bench_video_wayland(b: &mut Bencher) {
         gstreamer::init().unwrap();
-        let root = capturable::pipewire::get_capturables(false)
+        let root = capturable::pipewire::get_capturables(false, crate::config::PipewirePipeline::Auto)
             .unwrap()
             .remove(0);
         let mut r = root.recorder(false).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,7 +129,7 @@ mod tests {
     fn bench_capture_x11(b: &mut Bencher) {
         let mut x11ctx = capturable::x11::X11Context::new().unwrap();
         let root = x11ctx.capturables().unwrap().remove(0);
-        let mut r = root.recorder(false).unwrap();
+        let mut r = root.recorder(false, false).unwrap();
         b.iter(|| {
             r.capture().unwrap();
         });
@@ -140,7 +140,7 @@ mod tests {
     fn bench_video_x11(b: &mut Bencher) {
         let mut x11ctx = capturable::x11::X11Context::new().unwrap();
         let root = x11ctx.capturables().unwrap().remove(0);
-        let mut r = root.recorder(false).unwrap();
+        let mut r = root.recorder(false, false).unwrap();
         let (width, height) = r.capture().unwrap().size();
 
         let opts = video::EncoderOptions {
@@ -148,6 +148,7 @@ mod tests {
             try_nvenc: true,
             try_videotoolbox: false,
             try_mediafoundation: false,
+            input_is_dmabuf: false,
         };
         let mut encoder =
             video::VideoEncoder::new(width, height, width, height, |_| {}, opts).unwrap();
@@ -161,7 +162,7 @@ mod tests {
         let root = capturable::pipewire::get_capturables(false, crate::config::PipewirePipeline::Auto)
             .unwrap()
             .remove(0);
-        let mut r = root.recorder(false).unwrap();
+        let mut r = root.recorder(false, false).unwrap();
         let _ = r.capture();
         b.iter(|| {
             r.capture().unwrap();
@@ -175,7 +176,7 @@ mod tests {
         let root = capturable::pipewire::get_capturables(false, crate::config::PipewirePipeline::Auto)
             .unwrap()
             .remove(0);
-        let mut r = root.recorder(false).unwrap();
+        let mut r = root.recorder(false, false).unwrap();
         let (width, height) = r.capture().unwrap().size();
 
         let opts = video::EncoderOptions {
@@ -183,6 +184,7 @@ mod tests {
             try_nvenc: true,
             try_videotoolbox: false,
             try_mediafoundation: false,
+            input_is_dmabuf: false,
         };
         let mut encoder =
             video::VideoEncoder::new(width, height, width, height, |_| {}, opts).unwrap();
@@ -207,6 +209,7 @@ mod tests {
             try_nvenc: false,
             try_videotoolbox: false,
             try_mediafoundation: false,
+            input_is_dmabuf: false,
         };
         let mut encoder =
             video::VideoEncoder::new(WIDTH, HEIGHT, WIDTH, HEIGHT, |_| {}, opts).unwrap();
@@ -236,6 +239,7 @@ mod tests {
             try_nvenc: false,
             try_videotoolbox: false,
             try_mediafoundation: false,
+            input_is_dmabuf: false,
         };
         let mut encoder =
             video::VideoEncoder::new(WIDTH, HEIGHT, WIDTH, HEIGHT, |_| {}, opts).unwrap();
@@ -265,6 +269,7 @@ mod tests {
             try_nvenc: true,
             try_videotoolbox: false,
             try_mediafoundation: false,
+            input_is_dmabuf: false,
         };
         let mut encoder =
             video::VideoEncoder::new(WIDTH, HEIGHT, WIDTH, HEIGHT, |_| {}, opts).unwrap();

--- a/src/video.rs
+++ b/src/video.rs
@@ -16,6 +16,7 @@ extern "C" {
         try_nvenc: c_int,
         try_videotoolbox: c_int,
         try_mediafoundation: c_int,
+        input_dmabuf: c_int,
     ) -> *mut c_void;
     fn open_video(handle: *mut c_void, err: *mut CError);
     fn destroy_video_encoder(handle: *mut c_void);
@@ -24,6 +25,25 @@ extern "C" {
     fn fill_rgb(ctx: *mut c_void, data: *const u8, err: *mut CError);
     fn fill_rgb0(ctx: *mut c_void, data: *const u8, err: *mut CError);
     fn fill_bgr0(ctx: *mut c_void, data: *const u8, stride: c_int, err: *mut CError);
+
+    fn fill_dmabuf(
+        ctx: *mut c_void,
+        fd: c_int,
+        fourcc: u32,
+        modifier: u64,
+        stride: u32,
+        offset: u32,
+        err: *mut CError,
+    );
+
+    fn vaapi_encoder_available() -> c_int;
+}
+
+/// True when a VAAPI device opens and the `h264_vaapi` encoder is present.
+/// Gates the zero-copy dmabuf capture/encode path.
+#[cfg(target_os = "linux")]
+pub fn vaapi_available() -> bool {
+    unsafe { vaapi_encoder_available() != 0 }
 }
 
 // this is used as callback in lib/encode_video.c via ffmpegs AVIOContext
@@ -43,6 +63,17 @@ pub enum PixelProvider<'a> {
     BGR0(usize, usize, &'a [u8]),
     // width, height, stride
     BGR0S(usize, usize, usize, &'a [u8]),
+    // hardware dmabuf: fd + DRM layout, borrows nothing but ties to the
+    // recorder's retained GstBuffer via the PixelProvider<'a> lifetime.
+    DmaBuf {
+        fd: std::os::raw::c_int,
+        fourcc: u32,
+        modifier: u64,
+        width: usize,
+        height: usize,
+        stride: u32,
+        offset: u32,
+    },
 }
 
 impl<'a> PixelProvider<'a> {
@@ -52,6 +83,7 @@ impl<'a> PixelProvider<'a> {
             PixelProvider::RGB0(w, h, _) => (*w, *h),
             PixelProvider::BGR0(w, h, _) => (*w, *h),
             PixelProvider::BGR0S(w, h, _, _) => (*w, *h),
+            PixelProvider::DmaBuf { width, height, .. } => (*width, *height),
         }
     }
 }
@@ -62,6 +94,9 @@ pub struct EncoderOptions {
     pub try_nvenc: bool,
     pub try_videotoolbox: bool,
     pub try_mediafoundation: bool,
+    /// Frames will arrive as DRM-PRIME dmabufs (zero-copy VAAPI import). Set only
+    /// when the selected capture path actually ends up on the dmabuf path.
+    pub input_is_dmabuf: bool,
 }
 
 pub struct VideoEncoder {
@@ -103,6 +138,7 @@ impl VideoEncoder {
                 options.try_nvenc.into(),
                 options.try_videotoolbox.into(),
                 options.try_mediafoundation.into(),
+                options.input_is_dmabuf.into(),
             )
         };
         video_encoder.handle = handle;
@@ -129,6 +165,16 @@ impl VideoEncoder {
             },
             PixelProvider::RGB0(_, _, rgb) => unsafe {
                 fill_rgb0(self.handle, rgb.as_ptr(), &mut err);
+            },
+            PixelProvider::DmaBuf {
+                fd,
+                fourcc,
+                modifier,
+                stride,
+                offset,
+                ..
+            } => unsafe {
+                fill_dmabuf(self.handle, fd, fourcc, modifier, stride, offset, &mut err);
             },
         }
         if err.is_err() {

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -62,6 +62,8 @@ pub struct WeylusClientConfig {
     pub encoder_options: EncoderOptions,
     #[cfg(target_os = "linux")]
     pub wayland_support: bool,
+    #[cfg(target_os = "linux")]
+    pub pipewire_pipeline: crate::config::PipewirePipeline,
     pub no_gui: bool,
 }
 
@@ -200,6 +202,8 @@ impl<S, R, FnUInput> WeylusClientHandler<S, R, FnUInput> {
             self.config.wayland_support,
             #[cfg(target_os = "linux")]
             self.capture_cursor,
+            #[cfg(target_os = "linux")]
+            self.config.pipewire_pipeline,
         );
         self.capturables.iter().for_each(|c| {
             windows.push(c.name());

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -314,6 +314,15 @@ fn handle_video<S: WeylusSender + Clone + 'static>(
     let mut recorder: Option<Box<dyn Recorder>> = None;
     let mut video_encoder: Option<Box<VideoEncoder>> = None;
 
+    // VAAPI usable at all? Only then do we ask the capturer for a zero-copy dmabuf
+    // path (it never has to serve a software encoder).
+    #[cfg(target_os = "linux")]
+    let vaapi_ok = encoder_options.try_vaapi && crate::video::vaapi_available();
+    #[cfg(not(target_os = "linux"))]
+    let vaapi_ok = false;
+    // Whether the currently-selected recorder actually ended up on the dmabuf path.
+    let mut input_is_dmabuf = false;
+
     let mut max_width = 1920;
     let mut max_height = 1080;
     let mut frame_duration = EFFECTIVE_INIFINITY;
@@ -346,9 +355,16 @@ fn handle_video<S: WeylusSender + Clone + 'static>(
                     // This shouldn't affect other Recorder trait objects.
                     recorder = None;
                 }
-                match config.capturable.recorder(config.capture_cursor) {
+                match config.capturable.recorder(config.capture_cursor, vaapi_ok) {
                     Ok(r) => {
+                        // Reconcile: only put the encoder in dmabuf mode when the recorder
+                        // actually landed on the dmabuf path (Auto may fall back to
+                        // LinearCpu/GL, or this may be an X11 capturable).
+                        input_is_dmabuf = r.is_dmabuf();
                         recorder = Some(r);
+                        // Force the encoder to be rebuilt so its input mode matches the
+                        // new recorder's actual capture path.
+                        video_encoder = None;
                         max_width = config.max_width;
                         max_height = config.max_height;
                         send_message(&mut sender, MessageOutbound::ConfigOk);
@@ -415,6 +431,8 @@ fn handle_video<S: WeylusSender + Clone + 'static>(
                 {
                     send_message(&mut sender, MessageOutbound::NewVideo);
                     let mut sender = sender.clone();
+                    let mut encoder_options = encoder_options;
+                    encoder_options.input_is_dmabuf = input_is_dmabuf;
                     let res = VideoEncoder::new(
                         width_in,
                         height_in,

--- a/src/weylus.rs
+++ b/src/weylus.rs
@@ -45,6 +45,9 @@ impl Weylus {
             try_mediafoundation: config.try_mediafoundation,
             #[cfg(not(target_os = "windows"))]
             try_mediafoundation: false,
+
+            // Reconciled against the actual capture path in websocket::handle_video.
+            input_is_dmabuf: false,
         };
 
         let (sender_ui, mut receiver_ui) = tokio::sync::mpsc::channel(100);

--- a/src/weylus.rs
+++ b/src/weylus.rs
@@ -70,6 +70,8 @@ impl Weylus {
                 encoder_options,
                 #[cfg(target_os = "linux")]
                 wayland_support: config.wayland_support,
+                #[cfg(target_os = "linux")]
+                pipewire_pipeline: config.pipewire_pipeline,
                 no_gui: config.no_gui,
             },
         );


### PR DESCRIPTION
This makes the wayland path fully usable on niri/intel iGPU/Android table - there is a chance that at least some parts of it will be usable on different/compositors. 

Initially I planned to split this into separate PRs, but the thing got tangled very fast, so I'm left with this one big thing. 

The debug artifacts are intentionally included, to make troubleshooting of other combinations easier.

The things solved:
- Capturing screen in niri and feeding it directly to VAAPI, without CPU taking extra load - that's the big one
- Fixing stylus coordinate mapping on wayland (using information provided by compositor, extracted from pipewire metadata and with wayland xdg-outpus protocol)

Debugging and coding was mosltly done by AI.

Everything below is AI-generated
=========================

# 1. Capture -> encode: from black screen to zero-copy VAAPI

Told bottom-up: first make capture work, then make VAAPI encode work, then
combine the two with no CPU round trip. The whole path is selected by one
knob (`--pipewire-pipeline` / `WEYLUS_PIPEWIRE_PIPELINE` / GUI dropdown),
with `auto` cascading `direct -> dmabuf -> linear-cpu -> gl`.

## Capture (was: black screen)

Capturing a niri monitor was a black screen: GStreamer couldn't
negotiate/import the compositor's DMA-BUF, so weylus fell back to the X11
capturable, which can't see native Wayland windows. Added a GL DMA-BUF
import path (`pipewiresrc -> capsfilter -> glupload -> glcolorconvert ->
gldownload -> videoconvert -> appsink`) alongside the historic direct
`pipewiresrc -> appsink`.

**gst version requirement:** the GL path needs gst-plugins-base >= 1.28.0.
With 1.26.x, `glupload -> glcolorconvert -> gldownload` fails to link
through a restrictive DMABuf capsfilter (glupload returns empty caps
before any GL context exists). Fixed upstream in gst-plugins-base
8112ede49 ("gl: upload: Fix linking glupload with restrictive caps
filter"), released in 1.28.0; distros on 1.26.x must build against newer gst.

Three negotiation fixes, found against the niri/pipewiresrc sources:

- The capsfilter used `drm-format=(list)< ... >`. `< >` is a GstValueArray;
  alternatives must be `{ }` (GstValueList) or the link fails silently.
- vapostproc can't import XRGB8888 (XR24) as DMA-BUF, and a niri monitor
  offers only XR24. glupload imports it as an EGLImage instead.
- niri defaults to a multi-plane CCS modifier but the stream carries one
  plane, so eglCreateImage fails with EGL_BAD_MATCH. Restrict the
  capsfilter to single-plane non-CCS modifiers (LINEAR/X_TILED/Y_TILED);
  niri then negotiates Y_TILED cleanly.
- The GL path sets `always-copy=false` (niri's dmabufs carry the data in
  the fd with a 1-byte chunk, so `always-copy` would copy that byte and
  drop the fd). The direct path keeps `always-copy=true` (pw#982 teardown
  workaround).

The GStreamer bus is also drained on a failed state change so the real
error surfaces in weylus's log.

## VAAPI encoding (was: silent fallback to libx264)

`avfilter_graph_parse_ptr()` creates the hwupload filter internally, which
needs `hw_device_ctx` set before its init runs. The old code set it too
late (after the parse), so the filter failed and the whole VAAPI path
silently fell back to libx264. Create hwupload manually with
`hw_device_ctx` pre-set, then parse only the rest of the chain. All three
pixel-format scalers now upload to VAAPI and use `h264_vaapi`.

Fixes #200

## Zero-copy dmabuf -> VAAPI (the 120fps / no-extra-CPU win)

With both of the above working, capture->encode still did a full
GPU->CPU->GPU round trip every frame: the tiled DMA-BUF was imported on
the GPU, `gldownload`ed to system memory, then re-`hwupload`ed -- pointless,
since producer and consumer are the same GPU.

The `dmabuf` pipeline keeps the PipeWire buffer as a DMA_DRM dmabuf
(`pipewiresrc -> capsfilter(DMA_DRM) -> appsink`) and passes its fd + DRM
layout (fourcc, modifier, stride, offset) through a new
`PixelProvider::DmaBuf` variant straight to the encoder, which imports it
via ffmpeg `buffer(DRM_PRIME) -> hwmap=derive_device=vaapi ->
scale_vaapi=nv12 -> h264_vaapi`. No download, no re-upload, no CPU colour
convert.

The four pipelines, and how `auto` picks one:

- `direct`     -- historic `pipewiresrc -> appsink` (cheapest when it works).
- `dmabuf`     -- zero-copy VAAPI import (VAAPI encoder only). In `auto`,
                  attempted only when a startup probe confirms a VAAPI
                  device + `h264_vaapi` exist, so it never serves the x264
                  software encoder.
- `linear-cpu` -- GL download pinned to LINEAR; cheap (no de-tile) readback
                  where zero-copy is unavailable.
- `gl`         -- GL import + download (the original Wayland fallback).

The encoder is switched to dmabuf-input mode only when the recorder
actually landed on the dmabuf path (reconciled via `Recorder::is_dmabuf()`),
so X11 capture or an `auto` fallback still uses the normal frame-upload
encoder.

Two correctness details that cost real debugging time:

- **Thread the real DRM modifier.** niri fixates on Y_TILED
  (`0x0100000000000002`); telling VAAPI a tiled buffer is LINEAR makes it
  read tiled memory as linear -> all colours present but spatially
  scrambled. The modifier is parsed from the negotiated `drm-format` caps
  and carried through per frame.
- **Real render node + size cap.** The device must be
  `/dev/dri/renderD128` (override `WEYLUS_VAAPI_DRM_NODE`) -- ffmpeg
  `open()`s it, so NULL -> EFAULT. The VAAPI H.264 encoder caps at
  4096x4096, handled by the existing output scaling (5120x2160 -> 3840x1620).

Related issues (potentially fixed / may help diagnose): #3, #298, #338,
#341, #329, #155.

---

# 2. Stylus input landing on the wrong monitor

Weylus maps the tablet's normalised [0,1] axes onto a screen rectangle,
which the compositor decodes against its global logical bounding box. That
rectangle used to come from FLTK's screen geometry -- under Xwayland that's
the XRANDR/Xwayland space, not niri's logical space -- so on a mixed
fractional-scale multi-monitor setup it was shifted/clipped and the pen
landed wrong. Fractional scale itself isn't the bug (the axes are
normalised before being scaled); the bug is the FLTK-vs-compositor
coordinate-space mismatch.

The ScreenCast portal reports each captured monitor's rectangle in the
compositor's logical space, and selecting N monitors yields N separate
streams (one per output). Capture that per-stream rectangle and normalise
it against the global bounding box, queried directly over the Wayland
protocol (wl_output + xdg-output logical geometry) instead of trusting
FLTK/Xwayland. Window captures (dummy 1x1) and anything unresolved fall
back to the old whole-screen mapping, so this can only improve monitor
capture, never regress it. Linux-only, exercised only when Wayland capture
is on.

(Note: the browser-side "custom input area" does its own affine remap and
would double-transform on top of this; leave it unchecked for monitor
capture.)
