### PR TITLE
Fix VAAPI hardware encoding: set hw_device_ctx before hwupload filter init

### DIFF
--- a/examples/vaapi_probe.rs
+++ b/examples/vaapi_probe.rs
@@ -1,0 +1,55 @@
+// Minimal VAAPI encoder probe — no portal, no browser, no capture.
+// Just creates a VideoEncoder with try_vaapi=true, feeds synthetic
+// BGR0 frames, and lets the ffmpeg log tell us which encoder was selected.
+//
+// Run:
+//   cargo run --example vaapi_probe 2>&1 | grep -E '(Video:|ERROR|WARN|Scale filter|VAAPI|hwupload|vaapi)'
+
+// Pull in the needed modules the same way pw_probe.rs does.
+#[path = "../src/cerror.rs"]
+mod cerror;
+#[path = "../src/log.rs"]
+mod log;
+#[path = "../src/video.rs"]
+mod video;
+
+use std::sync::mpsc;
+
+fn main() {
+    let (tx, _rx) = mpsc::sync_channel::<String>(32);
+    log::setup_logging(tx);
+
+    const WIDTH: usize = 1920;
+    const HEIGHT: usize = 1080;
+
+    let mut buf = vec![0u8; WIDTH * HEIGHT * 4];
+    for j in 0..(WIDTH * HEIGHT) {
+        let off = j * 4;
+        buf[off] = ((j * 3) % 256) as u8;
+        buf[off + 1] = ((j * 5) % 256) as u8;
+        buf[off + 2] = ((j * 7) % 256) as u8;
+        buf[off + 3] = 0;
+    }
+
+    let opts = video::EncoderOptions {
+        try_vaapi: true,
+        try_nvenc: false,
+        try_videotoolbox: false,
+        try_mediafoundation: false,
+    };
+
+    let mut encoder = match video::VideoEncoder::new(WIDTH, HEIGHT, WIDTH, HEIGHT, |_| {}, opts) {
+        Ok(enc) => enc,
+        Err(e) => {
+            eprintln!("FAILED to create VideoEncoder: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    // Encode a few frames to exercise the pipeline.
+    for _ in 0..5 {
+        encoder.encode(video::PixelProvider::BGR0(WIDTH, HEIGHT, &buf));
+    }
+
+    eprintln!("\n--- vaapi_probe: done ---");
+}

--- a/lib/encode_video.c
+++ b/lib/encode_video.c
@@ -265,6 +265,9 @@ void init_scaler(
 	inputs->pad_idx = 0;
 	inputs->next = NULL;
 
+	int hwupload_created = 0;
+	AVFilterContext* hwupload_ctx = NULL;
+
 	switch (pix_fmt_out)
 	{
 	case AV_PIX_FMT_CUDA:
@@ -293,22 +296,61 @@ void init_scaler(
 		}
 		break;
 	case AV_PIX_FMT_VAAPI:
+	{
+		// Create hwupload filter manually so hw_device_ctx is set
+		// before the filter's init() is called.
+		const AVFilter* hwupload_filter = avfilter_get_by_name("hwupload");
+		if (!hwupload_filter)
+		{
+			ret = AVERROR(ENOSYS);
+			log_warn("hwupload filter not found");
+			goto end;
+		}
+		hwupload_ctx = avfilter_graph_alloc_filter(
+			ctx->filter_graph_scale, hwupload_filter, "hwupload");
+		if (!hwupload_ctx)
+		{
+			ret = AVERROR(ENOMEM);
+			log_warn("Cannot allocate hwupload filter");
+			goto end;
+		}
+		hwupload_ctx->hw_device_ctx = av_buffer_ref(hw_device_ctx);
+		ret = avfilter_init_dict(hwupload_ctx, NULL);
+		if (ret < 0)
+		{
+			log_warn("Cannot init hwupload filter: %s", av_err2str(ret));
+			goto end;
+		}
+		hwupload_created = 1;
+
 		if (pix_fmt_in == AV_PIX_FMT_RGB24)
+		{
+			// Chain: buffersrc -> scale -> hwupload -> buffersink
+			// Parsed "scale" connects to hwupload; we link
+			// hwupload -> buffersink manually below.
+			inputs->filter_ctx = hwupload_ctx;
 			snprintf(
 				args,
 				sizeof(args),
-				"scale=w=%d:h=%d:flags=fast_bilinear,hwupload",
+				"scale=w=%d:h=%d:flags=fast_bilinear",
 				width_out,
 				height_out);
+		}
 		else
+		{
+			// Chain: buffersrc -> hwupload -> scale_vaapi -> buffersink
+			// buffersrc -> hwupload is linked manually below.
+			outputs->filter_ctx = hwupload_ctx;
 			snprintf(
 				args,
 				sizeof(args),
-				"hwupload,scale_vaapi=w=%d:h=%d:format=%s:mode=fast",
+				"scale_vaapi=w=%d:h=%d:format=%s:mode=fast",
 				width_out,
 				height_out,
 				av_get_pix_fmt_name(pix_fmt_sw_out));
+		}
 		break;
+	}
 	default:
 		snprintf(args, sizeof(args), "scale=w=%d:h=%d:flags=fast_bilinear", width_out, height_out);
 	}
@@ -320,12 +362,30 @@ void init_scaler(
 		goto end;
 	}
 
-	for (unsigned int i = 0; i < ctx->filter_graph_scale->nb_filters; i++)
+	// For VAAPI with the hwupload filter created manually, complete the links.
+	if (hwupload_created)
 	{
-		AVFilterContext* filt = ctx->filter_graph_scale->filters[i];
-		if (strcmp(filt->filter->name, "hwupload") == 0)
+		if (pix_fmt_in == AV_PIX_FMT_RGB24)
 		{
-			filt->hw_device_ctx = av_buffer_ref(hw_device_ctx);
+			// buffersink receives from hwupload instead of directly
+			// from the parsed chain.
+			ret = avfilter_link(hwupload_ctx, 0, ctx->buffersink_scale_ctx, 0);
+			if (ret < 0)
+			{
+				log_warn("Cannot link hwupload to buffersink");
+				goto end;
+			}
+		}
+		else
+		{
+			// buffersrc feeds into hwupload.
+			ret = avfilter_link(
+				ctx->buffersrc_scale_ctx, 0, hwupload_ctx, 0);
+			if (ret < 0)
+			{
+				log_warn("Cannot link buffersrc to hwupload");
+				goto end;
+			}
 		}
 	}
 


### PR DESCRIPTION
DISCLAIMERs:
- The thing is almost fully debugged/generated by AI
- Tested only on Intel iGPU (that's why I've also left debug helper)

avfilter_graph_parse_ptr() internally creates and initializes the
hwupload filter, which requires hw_device_ctx to be set before its
init() function is called. The existing code set it in a loop after
the parse call, which is too late — the filter fails to initialize
and the whole VAAPI path falls back to libx264 software encoding.

Fix by manually creating the hwupload filter with hw_device_ctx
pre-set, then using avfilter_graph_parse_ptr() only for the
remaining filter chain (scale_vaapi / scale).

All three pixel-format scalers (bgr0, rgb0, rgb24) now correctly
upload frames to VAAPI and use h264_vaapi hardware encoding.

Fixes #200

examples/vaapi_probe.rs is a minimal test harness: no portal, no
browser — just synthetic BGR0 frames through the encoder. Run with:
  cargo run --example vaapi_probe
